### PR TITLE
Gp 31 group chat channels

### DIFF
--- a/packages/backend/prisma/migrations/20260407192331_add_messaging_models/migration.sql
+++ b/packages/backend/prisma/migrations/20260407192331_add_messaging_models/migration.sql
@@ -1,0 +1,52 @@
+-- CreateTable
+CREATE TABLE "Conversation" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "isGroup" BOOLEAN NOT NULL DEFAULT false,
+    "moduleId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ConversationMember" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConversationMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConversationMember_conversationId_userId_key" ON "ConversationMember"("conversationId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConversationMember" ADD CONSTRAINT "ConversationMember_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConversationMember" ADD CONSTRAINT "ConversationMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -35,30 +35,32 @@ enum ModuleType {
 }
 
 model User {
-  id                String               @id @default(cuid())
-  email             String               @unique
-  username          String               @unique
-  firstName         String
-  lastName          String
-  dob               DateTime
-  password          String
-  role              Role                 @default(ATHLETE)
-  emailVerified     Boolean              @default(false)
-  verificationToken String?
-  profilePicture    String?
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @updatedAt
+  id                        String               @id @default(cuid())
+  email                     String               @unique
+  username                  String               @unique
+  firstName                 String
+  lastName                  String
+  dob                       DateTime
+  password                  String
+  role                      Role                 @default(ATHLETE)
+  emailVerified             Boolean              @default(false)
+  verificationToken         String?
+  profilePicture            String?
+  createdAt                 DateTime             @default(now())
+  updatedAt                 DateTime             @updatedAt
 
-  memberships       Membership[]
-  createdModules    Module[]             @relation("CreatedModules")
-  moduleMemberships ModuleMembership[]
-  attendanceRecords Attendance[]         @relation("AttendanceMember")
-  markedAttendances Attendance[]         @relation("AttendanceMarkedBy")
-  createdEvents     Event[]              @relation("CreatedEvents")
-  announcements     Announcement[]
-  announcementLikes AnnouncementLike[]
-  agendas           Agenda[]
-  agendaLikes       AgendaLike[]
+  memberships               Membership[]
+  conversationMemberships   ConversationMember[]
+  sentMessages              Message[]            @relation("SentMessages")
+  createdModules            Module[]             @relation("CreatedModules")
+  moduleMemberships         ModuleMembership[]
+  attendanceRecords         Attendance[]         @relation("AttendanceMember")
+  markedAttendances         Attendance[]         @relation("AttendanceMarkedBy")
+  createdEvents             Event[]              @relation("CreatedEvents")
+  announcements             Announcement[]
+  announcementLikes         AnnouncementLike[]
+  agendas                   Agenda[]
+  agendaLikes               AgendaLike[]
 }
 
 model Gym {
@@ -110,6 +112,7 @@ model Module {
 
   createdBy       User?              @relation("CreatedModules", fields: [createdById], references: [id], onDelete: SetNull)
   attendances     Attendance[]
+  conversations   Conversation[]
   memberships     ModuleMembership[]
   events          Event[]
   announcements   Announcement[]
@@ -217,4 +220,41 @@ model AgendaLike {
   agenda    Agenda   @relation(fields: [agendaId], references: [id], onDelete: Cascade)
 
   @@unique([userId, agendaId])
+}
+
+model Conversation {
+  id        String    @id @default(cuid())
+  name      String?
+  isGroup   Boolean   @default(false)
+  moduleId  String?
+
+  module    Module?   @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  members   ConversationMember[]
+  messages  Message[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model ConversationMember {
+  id                String        @id @default(cuid())
+  conversationId    String
+  userId            String
+  conversation      Conversation  @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt         DateTime      @default(now())
+  @@unique([conversationId, userId]) 
+}
+
+model Message {
+  id                String        @id @default(cuid())
+  conversationId    String
+  senderId          String
+  content           String
+  isRead            Boolean       @default(false)
+
+  conversation      Conversation  @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  sender            User          @relation("SentMessages", fields: [senderId], references: [id], onDelete: Cascade)
+  createdAt         DateTime      @default(now())      
+  updatedAt         DateTime      @updatedAt
 }

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -8,6 +8,8 @@ import attendanceRoutes from "./routes/attendance.routes";
 import eventsRoutes from "./routes/events.routes";
 import announcementsRoutes from "./routes/announcements.routes";
 import agendasRoutes from "./routes/agenda.routes";
+import conversationRoutes from "./routes/conversation.routes";
+
 /* Express App */
 const app = express();
 
@@ -23,5 +25,6 @@ app.use("/api/modules", attendanceRoutes);
 app.use("/api/events", eventsRoutes);
 app.use("/api/modules/:moduleId/announcements", announcementsRoutes);
 app.use("/api/modules/:moduleId/agendas", agendasRoutes);
+app.use("/api/modules/conversations", conversationRoutes);
 
 export default app;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -25,6 +25,6 @@ app.use("/api/modules", attendanceRoutes);
 app.use("/api/events", eventsRoutes);
 app.use("/api/modules/:moduleId/announcements", announcementsRoutes);
 app.use("/api/modules/:moduleId/agendas", agendasRoutes);
-app.use("/api/modules/conversations", conversationRoutes);
+app.use("/api/conversations", conversationRoutes);
 
 export default app;

--- a/packages/backend/src/controllers/conversation.controller.ts
+++ b/packages/backend/src/controllers/conversation.controller.ts
@@ -7,12 +7,12 @@ import {
     getPrivateConversation,
 } from "../services/conversation.service";
 
-export async function getUserInboxPreviewsController (req: Request, res: Response) {
+export async function getUserInboxPreviewsController(req: Request, res: Response) {
     try {
         const userId = req.user?.userId;
 
         if (!userId) {
-            return res.status(401).json({ error: "Unauthtorized" });
+            return res.status(401).json({ error: "Unauthorized" });
         }
 
         const previews = await getUserInboxPreviews(userId);
@@ -24,31 +24,31 @@ export async function getUserInboxPreviewsController (req: Request, res: Respons
     }
 }
 
-export async function getMessagesController (req: Request, res: Response) {
+export async function getMessagesController(req: Request, res: Response) {
     try {
         const userId = req.user?.userId;
         const conversationId = req.params.conversationId as string;
 
         if (!userId) {
-            return res.status(400).json({ error: "Unauthorized" });
+            return res.status(401).json({ error: "Unauthorized" });
         }
-        
+
         await markMessageAsRead(conversationId, userId);
         const messages = await getMessages(conversationId, userId);
         return res.status(200).json({ messages });
     } catch (error) {
         const message = error instanceof Error ? error.message : "Internal server error";
-        
+
         if (message === "Not authorized") {
-            res.status(403).json({ error: message })
+            return res.status(403).json({ error: message });
         }
 
         console.error("Get messages error:", error);
-        return res.status(500).json({ error: "Internal server error"})
+        return res.status(500).json({ error: "Internal server error" });
     }
-} 
+}
 
-export async function sendMessageController (req: Request, res: Response) {
+export async function sendMessageController(req: Request, res: Response) {
     try {
         const userId = req.user?.userId;
         const conversationId = req.params.conversationId as string;
@@ -75,26 +75,43 @@ export async function sendMessageController (req: Request, res: Response) {
         console.error("Send message error:", error);
         return res.status(500).json({ error: "Internal server error" });
     }
-}  
+}
 
-export async function getPrivateConversationController (req: Request, res: Response) {
+export async function getPrivateConversationController(req: Request, res: Response) {
     try {
-        const userId = req.user?.userId 
+        const userId = req.user?.userId;
         const { otherUserId, moduleId } = req.body;
-        
+
         if (!userId) {
-          return  res.status(401).json({ error: "Unauthorized"});        
+            return res.status(401).json({ error: "Unauthorized" });
         }
 
         if (!otherUserId || !moduleId) {
-            return res.status(400).json({error: "otherUserId && moduleId are required"});
+            return res
+                .status(400)
+                .json({ error: "otherUserId and moduleId are required" });
         }
 
-        const conversation = await getPrivateConversation(userId, otherUserId, moduleId);
+        const conversation = await getPrivateConversation(
+            userId,
+            otherUserId,
+            moduleId
+        );
 
         return res.status(200).json({ conversation });
     } catch (error) {
-        console.error("Get private conversation error: ", error);
+        const message =
+            error instanceof Error ? error.message : "Internal server error";
+
+        if (message === "Cannot message yourself") {
+            return res.status(400).json({ error: message });
+        }
+
+        if (message === "Not authorized") {
+            return res.status(403).json({ error: message });
+        }
+
+        console.error("Get private conversation error:", error);
         return res.status(500).json({ error: "Internal server error" });
     }
 }

--- a/packages/backend/src/controllers/conversation.controller.ts
+++ b/packages/backend/src/controllers/conversation.controller.ts
@@ -1,0 +1,76 @@
+import { Request, Response } from "express";
+import {
+    getUserInboxPreviews,
+    getMessages,
+    sendMessage,
+} from "../services/conversation.service";
+
+export async function getUserInboxPreviewsController (req: Request, res: Response) {
+    try {
+        const userId = req.user?.userId;
+
+        if (!userId) {
+            return res.status(401).json({ error: "Unauthtorized" });
+        }
+
+        const previews = await getUserInboxPreviews(userId);
+
+        return res.status(200).json({ previews });
+    } catch (error) {
+        console.error("Get inbox previews error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+}
+
+export async function getMessagesController (req: Request, res: Response) {
+    try {
+        const userId = req.user?.userId;
+        const conversationId = req.params.conversationId as string;
+
+        if (!userId) {
+            return res.status(400).json({ error: "Unauthorized" });
+        }
+
+        const messages = await getMessages(conversationId, userId);
+
+        return res.status(200).json({ messages });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Internal server error";
+        
+        if (message === "Not authorized") {
+            res.status(403).json({ error: message })
+        }
+
+        console.error("Get messages error:", error);
+        return res.status(500).json({ error: "Internal server error"})
+    }
+} 
+
+export async function sendMessageController (req: Request, res: Response) {
+    try {
+        const userId = req.user?.userId;
+        const conversationId = req.params.conversationId as string;
+        const { content } = req.body;
+
+        if (!userId) {
+            return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        if (!content || typeof content !== "string") {
+            return res.status(400).json({ error: "Message content is required" });
+        }
+
+        const message = await sendMessage(conversationId, userId, content);
+
+        return res.status(201).json({ message: "Message sent successfully", data: message, });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Internal server error";
+
+        if (message === "Not authorized") {
+            return res.status(403).json({ error: message });
+        }
+
+        console.error("Send message error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+}   

--- a/packages/backend/src/controllers/conversation.controller.ts
+++ b/packages/backend/src/controllers/conversation.controller.ts
@@ -4,6 +4,7 @@ import {
     getMessages,
     sendMessage,
     markMessageAsRead,
+    getPrivateConversation,
 } from "../services/conversation.service";
 
 export async function getUserInboxPreviewsController (req: Request, res: Response) {
@@ -74,4 +75,26 @@ export async function sendMessageController (req: Request, res: Response) {
         console.error("Send message error:", error);
         return res.status(500).json({ error: "Internal server error" });
     }
-}   
+}  
+
+export async function getPrivateConversationController (req: Request, res: Response) {
+    try {
+        const userId = req.user?.userId 
+        const { otherUserId, moduleId } = req.body;
+        
+        if (!userId) {
+          return  res.status(401).json({ error: "Unauthorized"});        
+        }
+
+        if (!otherUserId || !moduleId) {
+            return res.status(400).json({error: "otherUserId && moduleId are required"});
+        }
+
+        const conversation = await getPrivateConversation(userId, otherUserId, moduleId);
+
+        return res.status(200).json({ conversation });
+    } catch (error) {
+        console.error("Get private conversation error: ", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+}

--- a/packages/backend/src/controllers/conversation.controller.ts
+++ b/packages/backend/src/controllers/conversation.controller.ts
@@ -3,6 +3,7 @@ import {
     getUserInboxPreviews,
     getMessages,
     sendMessage,
+    markMessageAsRead,
 } from "../services/conversation.service";
 
 export async function getUserInboxPreviewsController (req: Request, res: Response) {
@@ -30,9 +31,9 @@ export async function getMessagesController (req: Request, res: Response) {
         if (!userId) {
             return res.status(400).json({ error: "Unauthorized" });
         }
-
+        
+        await markMessageAsRead(conversationId, userId);
         const messages = await getMessages(conversationId, userId);
-
         return res.status(200).json({ messages });
     } catch (error) {
         const message = error instanceof Error ? error.message : "Internal server error";

--- a/packages/backend/src/controllers/modules.controller.ts
+++ b/packages/backend/src/controllers/modules.controller.ts
@@ -79,19 +79,19 @@ export async function listMyModulesController(req: Request, res: Response) {
   }
 }
 
-export async function joinModuleController(req: Request, res: Response){
-  try{
-    if (!req.user){
-      return res.status(401).json({ error: "Unauthorized"});
+export async function joinModuleController(req: Request, res: Response) {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ error: "Unauthorized" });
     }
 
     const { joinCode } = req.body;
 
     if (!joinCode || typeof joinCode !== "string") {
-      return res.status(400).json({ error: "Join code is required."});
+      return res.status(400).json({ error: "Join code is required." });
     }
 
-    const result = await joinModule(req.user.userId, joinCode, req.user.role);
+    const result = await joinModule(req.user.userId, joinCode);
 
     return res.status(201).json({
       message: "Successfully joined module",
@@ -110,7 +110,7 @@ export async function joinModuleController(req: Request, res: Response){
     }
 
     console.error("Join module error:", error);
-    return res.status(500).json({ error: "Internal server error"});
+    return res.status(500).json({ error: "Internal server error" });
   }
 }
 

--- a/packages/backend/src/lib 2/prisma.ts
+++ b/packages/backend/src/lib 2/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+    throw new Error("DATABASE_URL is not defined");
+}
+
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+
+export default prisma;

--- a/packages/backend/src/routes/conversation.routes.ts
+++ b/packages/backend/src/routes/conversation.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import  { requireAuth } from "../middleware/auth.middleware";
+import {
+    getUserInboxPreviewsController,
+    getMessagesController,
+    sendMessageController,
+}   from "../controllers/conversation.controller";
+
+const router = Router();
+
+router.get("/", requireAuth, getUserInboxPreviewsController);
+router.get("/:conversationId/messages", requireAuth, getMessagesController);
+router.post("/:conversationId/message", requireAuth, sendMessageController);
+
+export default router;

--- a/packages/backend/src/routes/conversation.routes.ts
+++ b/packages/backend/src/routes/conversation.routes.ts
@@ -4,6 +4,7 @@ import {
     getUserInboxPreviewsController,
     getMessagesController,
     sendMessageController,
+    getPrivateConversationController,
 }   from "../controllers/conversation.controller";
 
 const router = Router();
@@ -11,5 +12,6 @@ const router = Router();
 router.get("/", requireAuth, getUserInboxPreviewsController);
 router.get("/:conversationId/messages", requireAuth, getMessagesController);
 router.post("/:conversationId/message", requireAuth, sendMessageController);
+router.get("/:private", requireAuth, getPrivateConversationController);
 
 export default router;

--- a/packages/backend/src/routes/conversation.routes.ts
+++ b/packages/backend/src/routes/conversation.routes.ts
@@ -1,17 +1,16 @@
 import { Router } from "express";
-import  { requireAuth } from "../middleware/auth.middleware";
+import { requireAuth } from "../middleware/auth.middleware";
 import {
     getUserInboxPreviewsController,
     getMessagesController,
     sendMessageController,
     getPrivateConversationController,
-}   from "../controllers/conversation.controller";
+} from "../controllers/conversation.controller";
 
 const router = Router();
 
 router.get("/", requireAuth, getUserInboxPreviewsController);
 router.get("/:conversationId/messages", requireAuth, getMessagesController);
 router.post("/:conversationId/message", requireAuth, sendMessageController);
-router.get("/:private", requireAuth, getPrivateConversationController);
-
+router.post("/private", requireAuth, getPrivateConversationController);
 export default router;

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -1,6 +1,6 @@
 import prisma from "../lib/prisma";
 
-export async function createGroupConversation( moduleId: string, name: string, memberIds: string[] ) {
+export async function createGroupConversation(moduleId: string, name: string, memberIds: string[]) {
     return prisma.conversation.create({
         data: {
             name,
@@ -14,12 +14,12 @@ export async function createGroupConversation( moduleId: string, name: string, m
         },
         include: {
             members: true,
-            },
-        });
+        },
+    });
 }
 
-export async function getUserInboxPreviews( userId: string ) {
-     const conversations = await prisma.conversation.findMany({
+export async function getUserInboxPreviews(userId: string) {
+    const conversations = await prisma.conversation.findMany({
         where: {
             members: {
                 some: {
@@ -52,22 +52,22 @@ export async function getUserInboxPreviews( userId: string ) {
             id: conversation.id,
             name: conversation.name,
             isGroup: conversation.isGroup,
-            latestMessage: latestMessage?.content || null, 
+            latestMessage: latestMessage?.content || null,
             latestMessageTime: latestMessage?.createdAt || null,
             hasUnread:
                 latestMessage &&
                 latestMessage.senderId !== userId &&
                 !latestMessage.isRead,
-            members: conversation.members.map((m) => ({
-                id: m.user.id,
-                firstName: m.user.firstName,
-                lasttName: m.user.lastName,
+            members: conversation.members.map((member) => ({
+                id: member.user.id,
+                firstName: member.user.firstName,
+                lastName: member.user.lastName,
             })),
         };
     });
 }
 
-export async function getMessages( conversationId: string, userId: string ) {
+export async function getMessages(conversationId: string, userId: string) {
     const membership = await prisma.conversationMember.findFirst({
         where: {
             conversationId,
@@ -79,7 +79,7 @@ export async function getMessages( conversationId: string, userId: string ) {
         throw new Error("Not authorized");
     }
 
-    return prisma.message.findMany ({
+    return prisma.message.findMany({
         where: {
             conversationId,
         },
@@ -94,7 +94,7 @@ export async function getMessages( conversationId: string, userId: string ) {
 
 export async function sendMessage(
     conversationId: string,
-    senderId: string, 
+    senderId: string,
     content: string
 ) {
     const membership = await prisma.conversationMember.findFirst({
@@ -105,7 +105,7 @@ export async function sendMessage(
     });
 
     if (!membership) {
-        throw new Error ("Not authorized");
+        throw new Error("Not authorized");
     }
 
     const message = await prisma.message.create({
@@ -137,7 +137,7 @@ export async function markMessageAsRead(conversationId: string, userId: string) 
     });
 
     if (!membership) {
-        throw new Error ("Not authorized");
+        throw new Error("Not authorized");
     }
 
     return prisma.message.updateMany({
@@ -170,7 +170,7 @@ export async function createRoleBasedGroupChats(moduleId: string) {
     );
 }
 
-export async function addUserToRoleGroupChat( moduleId: string, userId: string, role: string) {
+export async function addUserToRoleGroupChat(moduleId: string, userId: string, role: string) {
     let conversationName: string | null = null;
 
     if (role === "ATHLETE") {
@@ -180,6 +180,7 @@ export async function addUserToRoleGroupChat( moduleId: string, userId: string, 
     } else if (role === "COACH") {
         conversationName = "Coach Chat";
     }
+
 
     if (!conversationName) {
         return null;
@@ -193,8 +194,8 @@ export async function addUserToRoleGroupChat( moduleId: string, userId: string, 
         },
     });
 
-    if(!conversation) {
-        throw new Error ("Group conversation not found");
+    if (!conversation) {
+        throw new Error("Group conversation not found");
     }
 
     return prisma.conversationMember.upsert({
@@ -212,85 +213,125 @@ export async function addUserToRoleGroupChat( moduleId: string, userId: string, 
     });
 }
 
-export async function findPrivateConversation (userId: string, otherUserId: string, moduleId: string) {
-  const conversations = prisma.conversation.findMany({
-    where: {
-      moduleId,
-      isGroup: false,
-      members: {
-        some: {
-          userId: {
-            in: [userId, otherUserId],
-          },
+export async function findPrivateConversation(userId: string, otherUserId: string, moduleId: string) {
+    const conversations = prisma.conversation.findMany({
+        where: {
+            moduleId,
+            isGroup: false,
+            members: {
+                some: {
+                    userId: {
+                        in: [userId, otherUserId],
+                    },
+                },
+            },
         },
-      },
-    },
-    include: {
-      members: true,
-    }
-  });
+        include: {
+            members: true,
+        }
+    });
 
-  return (await conversations).find((conversation) =>{
-    const memberIds = conversation.members.map((m) => m.userId);
+    return (await conversations).find((conversation) => {
+        const memberIds = conversation.members.map((m) => m.userId);
 
-    return (
-      memberIds.length === 2 && 
-      memberIds.includes(userId) && 
-      memberIds.includes(otherUserId)
-    );
-  }) || null;
+        return (
+            memberIds.length === 2 &&
+            memberIds.includes(userId) &&
+            memberIds.includes(otherUserId)
+        );
+    }) || null;
 }
 
-export async function createPrivateConversation (userId: string, otherUserId: string, moduleId: string){
-  return prisma.conversation.create({
-    data: {
-      moduleId,
-      isGroup: false,
-      members: {
-        create: [ 
-          { userId },
-          { userId: otherUserId }, 
-        ],
-      },
-    },
-    include: {
-      members: true,
-    }
-  });
+export async function createPrivateConversation(userId: string, otherUserId: string, moduleId: string) {
+    return prisma.conversation.create({
+        data: {
+            moduleId,
+            isGroup: false,
+            members: {
+                create: [
+                    { userId },
+                    { userId: otherUserId },
+                ],
+            },
+        },
+        include: {
+            members: true,
+        }
+    });
 }
 
 //Will create conversation if it doesn't exist
-export async function getPrivateConversation(
-  userId: string,
-  otherUserId: string,
-  moduleId: string
-) {
-  if (userId === otherUserId) {
-    throw new Error("Cannot message yourself");
-  }
+export async function getPrivateConversation(userId: string, otherUserId: string, moduleId: string) {
+    if (userId === otherUserId) {
+        throw new Error("Cannot message yourself");
+    }
 
-  const memberships = await prisma.moduleMembership.findMany({
-    where: {
-      moduleId,
-      userId: {
-        in: [userId, otherUserId],
-      },
-    },
-  });
+    const memberships = await prisma.moduleMembership.findMany({
+        where: {
+            moduleId,
+            userId: {
+                in: [userId, otherUserId],
+            },
+        },
+    });
 
-  if (memberships.length !== 2) {
-    throw new Error("Not authorized");
-  }
+    if (memberships.length !== 2) {
+        throw new Error("Not authorized");
+    }
 
-  const existingConversation = await findPrivateConversation(
-    userId,
-    otherUserId,
-    moduleId
-  );
+    const users = await prisma.user.findMany({
+        where: {
+            id: {
+                in: [userId, otherUserId],
+            },
+        },
+        select: {
+            id: true,
+            role: true,
+        },
+    });
 
-  if (existingConversation) {
-    return existingConversation;
-  }
+    const currentUser = users.find((user) => user.id === userId);
+    const otherUser = users.find((user) => user.id === otherUserId);
 
-  return createPrivateConversation(userId, otherUserId, moduleId);
+    if (!currentUser || !otherUser) {
+        throw new Error("Not authorized");
+    }
+
+    const canMessage = canInitiatePrivateConversation(
+        currentUser.role,
+        otherUser.role
+    );
+
+    if (!canMessage) {
+        throw new Error("Not authorized");
+    }
+
+    const existingConversation = await findPrivateConversation(
+        userId,
+        otherUserId,
+        moduleId
+    );
+
+    if (existingConversation) {
+        return existingConversation;
+    }
+
+    return createPrivateConversation(userId, otherUserId, moduleId);
+}
+
+function canInitiatePrivateConversation(senderRole: string, targetRole: string) {
+    if (senderRole === "COACH") {
+        return ["COACH", "ATHLETE", "PARENT"].includes(targetRole);
+    }
+
+    if (senderRole === "ATHLETE") {
+        return ["COACH", "ATHLETE"].includes(targetRole);
+    }
+
+    if (senderRole === "PARENT") {
+        return ["PARENT", "ATHLETE"].includes(targetRole);
+    }
+
+    return false;
 }

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -1,0 +1,72 @@
+import prisma from "../lib/prisma";
+
+export async function createGroupConversation( moduleId: string, name: string, memberIds: string[] ) {
+    return prisma.conversation.create({
+        data: {
+            name,
+            isGroup: true,
+            moduleId,
+            members: {
+                create: memberIds.map((userId) => ({
+                    userId,
+                })),
+            },
+        },
+        include: {
+            members: true,
+            },
+        });
+}
+
+export async function getUserInboxPreviews( userId: string ) {
+    return prisma.conversation.findMany({
+        where: {
+            members: {
+                some: {
+                    userId,
+                },
+            },
+        },
+        include: {
+            members: {
+                include: {
+                    user: true,
+                },
+            },
+            messages: {
+                orderBy: {
+                    createdAt: "desc",
+                },
+                take: 1,
+            },
+        },
+        orderBy: {
+            updatedAt: "desc",
+        },
+    });
+}
+
+export async function getConversationMessages( conversationId: string, userId: string ) {
+    const membership = await prisma.conversationMember.findFirst({
+        where: {
+            conversationId,
+            userId,
+        },
+    });
+
+    if (!membership) {
+        throw new Error("Not authorized");
+    }
+
+    return prisma.message.findMany ({
+        where: {
+            conversationId,
+        },
+        include: {
+            sender: true,
+        },
+        orderBy: {
+            createdAt: "asc",
+        },
+    });
+}

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -70,3 +70,39 @@ export async function getConversationMessages( conversationId: string, userId: s
         },
     });
 }
+
+export async function sendMessage(
+    conversationId: string,
+    senderId: string, 
+    content: string
+) {
+    const membership = await prisma.conversationMember.findFirst({
+        where: {
+            conversationId,
+            userId: senderId,
+        },
+    });
+
+    if (!membership) {
+        throw new Error ("Not authorized");
+    }
+
+    const message = await prisma.message.create({
+        data: {
+            conversationId,
+            senderId,
+            content,
+        }
+    });
+
+    await prisma.conversation.update({
+        where: {
+            id: conversationId,
+        },
+        data: {
+            updatedAt: new Date(),
+        },
+    });
+
+    return message;
+}

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -19,7 +19,7 @@ export async function createGroupConversation( moduleId: string, name: string, m
 }
 
 export async function getUserInboxPreviews( userId: string ) {
-    return prisma.conversation.findMany({
+     const conversations = await prisma.conversation.findMany({
         where: {
             members: {
                 some: {
@@ -43,6 +43,27 @@ export async function getUserInboxPreviews( userId: string ) {
         orderBy: {
             updatedAt: "desc",
         },
+    });
+
+    return conversations.map((conversation) => {
+        const latestMessage = conversation.messages[0];
+
+        return {
+            id: conversation.id,
+            name: conversation.name,
+            isGroup: conversation.isGroup,
+            latestMessage: latestMessage?.content || null, 
+            latestMessageTime: latestMessage?.createdAt || null,
+            hasUnread:
+                latestMessage &&
+                latestMessage.senderId !== userId &&
+                !latestMessage.isRead,
+            members: conversation.members.map((m) => ({
+                id: m.user.id,
+                firstName: m.user.firstName,
+                lasttName: m.user.lastName,
+            })),
+        };
     });
 }
 

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -46,7 +46,7 @@ export async function getUserInboxPreviews( userId: string ) {
     });
 }
 
-export async function getConversationMessages( conversationId: string, userId: string ) {
+export async function getMessages( conversationId: string, userId: string ) {
     const membership = await prisma.conversationMember.findFirst({
         where: {
             conversationId,

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -106,3 +106,29 @@ export async function sendMessage(
 
     return message;
 }
+
+export async function markMessageAsRead(conversationId: string, userId: string) {
+    const membership = await prisma.conversationMember.findFirst({
+        where: {
+            conversationId,
+            userId,
+        },
+    });
+
+    if (!membership) {
+        throw new Error ("Not authorized");
+    }
+
+    return prisma.message.updateMany({
+        where: {
+            conversationId,
+            senderId: {
+                not: userId,
+            },
+            isRead: false,
+        },
+        data: {
+            isRead: true,
+        },
+    });
+}

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -84,7 +84,16 @@ export async function getMessages(conversationId: string, userId: string) {
             conversationId,
         },
         include: {
-            sender: true,
+            sender: {
+                select: {
+                    id: true,
+                    username: true,
+                    firstName: true,
+                    lastName: true,
+                    role: true,
+                    profilePicture: true,
+                },
+            },
         },
         orderBy: {
             createdAt: "asc",

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -209,5 +209,63 @@ export async function addUserToRoleGroupChat( moduleId: string, userId: string, 
             conversationId: conversation.id,
             userId,
         }
-    })
+    });
+}
+
+export async function findPrivateConversation (userId: string, otherUserId: string, moduleId: string) {
+  const conversations = prisma.conversation.findMany({
+    where: {
+      moduleId,
+      isGroup: false,
+      members: {
+        some: {
+          userId: {
+            in: [userId, otherUserId],
+          },
+        },
+      },
+    },
+    include: {
+      members: true,
+    }
+  });
+
+  return (await conversations).find((conversation) =>{
+    const memberIds = conversation.members.map((m) => m.userId);
+
+    return (
+      memberIds.length === 2 && 
+      memberIds.includes(userId) && 
+      memberIds.includes(otherUserId)
+    );
+  }) || null;
+}
+
+export async function createPrivateconversation (userId: string, otherUserId: string, moduleId: string){
+  return prisma.conversation.create({
+    data: {
+      moduleId,
+      isGroup: false,
+      members: {
+        create: [ 
+          { userId },
+          { userId: otherUserId }, 
+        ],
+      },
+    },
+    include: {
+      members: true,
+    }
+  });
+}
+
+//Will create conversation if it doesn't exist
+export async function getPrivateConversation (userId: string, otherUserId: string, moduleId: string) {
+  const existingConversation = await findPrivateConversation(userId, otherUserId, moduleId);
+
+  if (existingConversation) {
+    return existingConversation;
+  }
+
+  return createPrivateconversation(userId, otherUserId, moduleId);
 }

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -241,7 +241,7 @@ export async function findPrivateConversation (userId: string, otherUserId: stri
   }) || null;
 }
 
-export async function createPrivateconversation (userId: string, otherUserId: string, moduleId: string){
+export async function createPrivateConversation (userId: string, otherUserId: string, moduleId: string){
   return prisma.conversation.create({
     data: {
       moduleId,
@@ -260,12 +260,37 @@ export async function createPrivateconversation (userId: string, otherUserId: st
 }
 
 //Will create conversation if it doesn't exist
-export async function getPrivateConversation (userId: string, otherUserId: string, moduleId: string) {
-  const existingConversation = await findPrivateConversation(userId, otherUserId, moduleId);
+export async function getPrivateConversation(
+  userId: string,
+  otherUserId: string,
+  moduleId: string
+) {
+  if (userId === otherUserId) {
+    throw new Error("Cannot message yourself");
+  }
+
+  const memberships = await prisma.moduleMembership.findMany({
+    where: {
+      moduleId,
+      userId: {
+        in: [userId, otherUserId],
+      },
+    },
+  });
+
+  if (memberships.length !== 2) {
+    throw new Error("Not authorized");
+  }
+
+  const existingConversation = await findPrivateConversation(
+    userId,
+    otherUserId,
+    moduleId
+  );
 
   if (existingConversation) {
     return existingConversation;
   }
 
-  return createPrivateconversation(userId, otherUserId, moduleId);
+  return createPrivateConversation(userId, otherUserId, moduleId);
 }

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -153,3 +153,61 @@ export async function markMessageAsRead(conversationId: string, userId: string) 
         },
     });
 }
+
+export async function createRoleBasedGroupChats(moduleId: string) {
+    const chats = ["Athlete Chat", "Parent Chat", "Coach Chat"];
+
+    return Promise.all(
+        chats.map((name) =>
+            prisma.conversation.create({
+                data: {
+                    name,
+                    isGroup: true,
+                    moduleId,
+                },
+            })
+        )
+    );
+}
+
+export async function addUserToRoleGroupChat( moduleId: string, userId: string, role: string) {
+    let conversationName: string | null = null;
+
+    if (role === "ATHLETE") {
+        conversationName = "Athlete Chat";
+    } else if (role === "PARENT") {
+        conversationName = "Parent Chat";
+    } else if (role === "COACH") {
+        conversationName = "Coach Chat";
+    }
+
+    if (!conversationName) {
+        return null;
+    }
+
+    const conversation = await prisma.conversation.findFirst({
+        where: {
+            moduleId,
+            isGroup: true,
+            name: conversationName,
+        },
+    });
+
+    if(!conversation) {
+        throw new Error ("Group conversation not found");
+    }
+
+    return prisma.conversationMember.upsert({
+        where: {
+            conversationId_userId: {
+                conversationId: conversation.id,
+                userId,
+            },
+        },
+        update: {},
+        create: {
+            conversationId: conversation.id,
+            userId,
+        }
+    })
+}

--- a/packages/backend/src/services/modules.service.ts
+++ b/packages/backend/src/services/modules.service.ts
@@ -35,6 +35,17 @@ export async function createModule(userId: string, name: string, description?: s
   });
 
   await createRoleBasedGroupChats(module.id);
+
+  const creator = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  });
+
+  if (!creator) {
+    throw new Error("User not found");
+  }
+
+  await addUserToRoleGroupChat(module.id, userId, creator.role);
   return module;
 }
 
@@ -75,25 +86,38 @@ export async function listMyModules(userId: string) {
 }
 
 //add module
-export async function joinModule(userId: string, joinCode: string, userRole: string)
-{
-  // find module by join code
+export async function joinModule(userId: string, joinCode: string) {
   const module = await prisma.module.findUnique({
-    where: { joinCode },
-  });
-
-  if (!module){
-    throw new Error("Invalid join code");
-  }
-  //check if already a member
-  const existingMem = await prisma.moduleMembership.findUnique({
     where: {
-      userId_moduleId: { userId, moduleId: module.id},
+      joinCode
     },
   });
 
-  if (existingMem){
+  if (!module) {
+    throw new Error("Invalid join code");
+  }
+
+  const existingMem = await prisma.moduleMembership.findUnique({
+    where: {
+      userId_moduleId: { userId, moduleId: module.id },
+    },
+  });
+
+  if (existingMem) {
     throw new Error("Already a member");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: {
+      id: userId
+    },
+    select: {
+      role: true
+    },
+  });
+
+  if (!user) {
+    throw new Error("User not found");
   }
 
   const memberRole = "MEMBER";
@@ -106,7 +130,8 @@ export async function joinModule(userId: string, joinCode: string, userRole: str
     },
   });
 
-  await addUserToRoleGroupChat(module.id, userId, userRole);
+  await addUserToRoleGroupChat(module.id, userId, user.role);
+
   return { module, membership };
 }
 
@@ -119,12 +144,13 @@ export async function getModuleInfo(moduleId: string, userId: string) {
   });
 
   if (!module) {
-    throw new Error("Module not found");}
-  
+    throw new Error("Module not found");
+  }
+
   const membership = module.memberships.find(
     (member: { userId: string }) => member.userId === userId);
-  
-  if(!membership){
+
+  if (!membership) {
     throw new Error("Not authorized");
   }
 

--- a/packages/backend/src/services/modules.service.ts
+++ b/packages/backend/src/services/modules.service.ts
@@ -212,3 +212,4 @@ export async function getModuleRoster(moduleId: string, userId: string) {
     profilePicture: membership.user.profilePicture,
   }));
 }
+

--- a/packages/backend/src/services/modules.service.ts
+++ b/packages/backend/src/services/modules.service.ts
@@ -1,5 +1,6 @@
 import prisma from "../lib/prisma";
 import { generateJoinCode } from "../utils/generateJoinCode";
+import { createRoleBasedGroupChats, addUserToRoleGroupChat } from "./conversation.service";
 
 async function generateUniqueJoinCode(): Promise<string> {
   let joinCode = generateJoinCode();
@@ -33,6 +34,7 @@ export async function createModule(userId: string, name: string, description?: s
     },
   });
 
+  await createRoleBasedGroupChats(module.id);
   return module;
 }
 
@@ -94,8 +96,7 @@ export async function joinModule(userId: string, joinCode: string, userRole: str
     throw new Error("Already a member");
   }
 
-  //coaches get admin access??
-  const memberRole = userRole === "COACH" ? "MODULE_ADMIN" : "MEMBER";
+  const memberRole = "MEMBER";
 
   const membership = await prisma.moduleMembership.create({
     data: {
@@ -105,6 +106,7 @@ export async function joinModule(userId: string, joinCode: string, userRole: str
     },
   });
 
+  await addUserToRoleGroupChat(module.id, userId, userRole);
   return { module, membership };
 }
 

--- a/postman/messaging-tests.postman_collection.json
+++ b/postman/messaging-tests.postman_collection.json
@@ -1,0 +1,1340 @@
+{
+  "info": {
+    "_postman_id": "864401aa-f6b1-47f2-bc41-1edb5fe17120",
+    "name": "Messaging Tests",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "51600719"
+  },
+  "item": [
+    {
+      "name": "Login - coach2",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityCoach2Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"coach2@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - varsityCoach1",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityCoach1Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"varsityCoach1@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - varsityAthlete1",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityAthlete1Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"varsityAthlete1@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - varsityAthlete2",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityAthlete2Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"athlete2@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - varsityAthlete3",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityAthlete3Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"varsityAthlete3@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - varsityParent1",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityParent1Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"varsityParent1@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login - varsityParent2",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.collectionVariables.set(\"varsityParent2Token\", pm.response.json().token);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"identifier\": \"varsityParent2@test.com\",\n  \"password\": \"Asdf123!\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Module - coach2",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const res = pm.response.json();",
+              "",
+              "if (pm.response.code === 201 && res.module) {",
+              "  pm.collectionVariables.set(\"moduleId\", res.module.id);",
+              "  pm.collectionVariables.set(\"joinCode\", res.module.joinCode);",
+              "}"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityCoach2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Varsity Cheer Final Test\",\n  \"description\": \"Messaging test\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Join Module - varsityCoach1",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityCoach1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"joinCode\": \"{{joinCode}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules/join",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules",
+            "join"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Join Module - varsityAthlete1",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"joinCode\": \"{{joinCode}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules/join",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules",
+            "join"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Join Module - varsityAthlete2",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"joinCode\": \"{{joinCode}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules/join",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules",
+            "join"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Join Module - varsityAthlete3",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete3Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"joinCode\": \"{{joinCode}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules/join",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules",
+            "join"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Join Module - varsityParent1",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityParent1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"joinCode\": \"{{joinCode}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules/join",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules",
+            "join"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Join Module - varsityParent2",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityParent2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"joinCode\": \"{{joinCode}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/modules/join",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "modules",
+            "join"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Coach2",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const res = pm.response.json();",
+              "",
+              "if (pm.response.code === 200 && Array.isArray(res.previews)) {",
+              "  const coachChat = res.previews.find((p) => p.name === \"Coach Chat\");",
+              "",
+              "  if (coachChat) {",
+              "    pm.collectionVariables.set(\"coachChatId\", coachChat.id);",
+              "  }",
+              "}"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityCoach2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Coach1",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityCoach1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Athlete1",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const res = pm.response.json();",
+              "",
+              "if (pm.response.code === 200 && Array.isArray(res.previews)) {",
+              "  const athleteChat = res.previews.find((p) => p.name === \"Athlete Chat\");",
+              "",
+              "  if (athleteChat) {",
+              "    pm.collectionVariables.set(\"athleteChatId\", athleteChat.id);",
+              "",
+              "    const otherAthlete = athleteChat.members.find(",
+              "      (m) => m.lastName === \"Two\"",
+              "    );",
+              "",
+              "    if (otherAthlete) {",
+              "      pm.collectionVariables.set(\"otherUserId\", otherAthlete.id);",
+              "    }",
+              "  }",
+              "}"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Athlete2",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const res = pm.response.json();",
+              "",
+              "if (pm.response.code === 200 && Array.isArray(res.previews)) {",
+              "  const athleteChat = res.previews.find((p) => p.name === \"Athlete Chat\");",
+              "",
+              "  if (athleteChat) {",
+              "    pm.collectionVariables.set(\"athleteChatId\", athleteChat.id);",
+              "",
+              "    const knownAthlete2 = athleteChat.members.find(",
+              "      (m) => m.lastName === \"Two\"",
+              "    );",
+              "",
+              "    if (knownAthlete2) {",
+              "      pm.collectionVariables.set(\"otherUserId\", knownAthlete2.id);",
+              "    }",
+              "  }",
+              "}"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Athlete3",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete3Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Parent1",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const res = pm.response.json();",
+              "",
+              "if (pm.response.code === 200 && Array.isArray(res.previews)) {",
+              "  const parentChat = res.previews.find((p) => p.name === \"Parent Chat\");",
+              "",
+              "  if (parentChat) {",
+              "    pm.collectionVariables.set(\"parentChatId\", parentChat.id);",
+              "  }",
+              "}"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityParent1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Inbox - Parent2",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityParent2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Send Message - Athlete Chat (Athlete1)",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"content\": \"Hello Athletes from Athlete1\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{athleteChatId}}/message",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{athleteChatId}}",
+            "message"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Message - Athlete Chat (Athlete2)",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{athleteChatId}}/messages",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{athleteChatId}}",
+            "messages"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Send Message - Coach Chat (Coach2)",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityCoach2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"content\": \"Hello Coaches from Coach2\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{coachChatId}}/message",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{coachChatId}}",
+            "message"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Message -  Coach Chat (Coach1)",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityCoach1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{coachChatId}}/messages",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{coachChatId}}",
+            "messages"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Send Message -  Parent Chat (Parent1)",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityParent1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"content\": \"Hello from Parents from Parent1\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{parentChatId}}/message",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{parentChatId}}",
+            "message"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Message -  Parent Chat (Parent2)",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityParent2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{parentChatId}}/messages",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{parentChatId}}",
+            "messages"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get/Create Private Conversation (Athlete 1 -> Athlete2)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const res = pm.response.json();",
+              "",
+              "if (pm.response.code === 200 && res.conversation) {",
+              "  pm.collectionVariables.set(\"privateChatId\", res.conversation.id);",
+              "}"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"otherUserId\": \"{{otherUserId}}\",\n  \"moduleId\": \"{{moduleId}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/private",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "private"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Send Private Message (Athlete 1 -> Athlete2)",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete1Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"content\": \"Private message test\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{privateChatId}}/message",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{privateChatId}}",
+            "message"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Private Messages (Athlete2)",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete2Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{privateChatId}}/messages",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{privateChatId}}",
+            "messages"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Private Messages (Athlete3)",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{varsityAthlete3Token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/conversations/{{privateChatId}}/messages",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "conversations",
+            "{{privateChatId}}",
+            "messages"
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{varsityCoach2Token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000",
+      "type": "string"
+    },
+    {
+      "key": "varsityCoach2Token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "varsityCoach1Token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "varsityAthlete1Token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "varsityAthlete2Token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "varsityParent1Token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "coachChatId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "athleteChatId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "parentChatId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "privateChatId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "moduleId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "otherUserId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "joinCode",
+      "value": "",
+      "type": "default"
+    },
+    {
+      "key": "varsityAthlete3Token",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "varsityParent2Token",
+      "value": "",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
## PR: Messaging Backend (GP-31, GP-32, GP-15)

---

## Summary
- Implemented full messaging backend system
- Added:
  - role-based group chats (Coach, Athlete, Parent)
  - private 1-on-1 conversations scoped to modules
  - messaging endpoints (send, fetch, mark read)
- Enforced authentication and strict conversation-level authorization
- Added Postman collection for full end-to-end testing

---

## Changes Made

### Messaging System
- Implemented conversation model usage for:
  - group chats (per role)
  - private conversations (per module)
- Added automatic group chat creation on module creation
- Added automatic user assignment to correct group chat based on role

---

### Endpoints

#### Conversations
- `GET /api/conversations`
  - fetch inbox previews (latest message, members, unread state)

- `POST /api/conversations/private`
  - get or create private conversation between two users within a module

---

#### Messages
- `GET /api/conversations/:conversationId/messages`
  - fetch messages for a conversation
  - marks messages as read

- `POST /api/conversations/:conversationId/message`
  - send message to a conversation

---

### Authorization / Security
- Enforced:
  - user must be a member of conversation to access messages
  - user must belong to module to create/access conversations
- Private conversations restricted to participants only (403 otherwise)
- Fixed sensitive data leak:
  - removed `password` and `verificationToken` from message sender payload

---

### Postman Testing
- Added Postman collection:
/postman/messaging-tests.postman_collection.json

- Covers:
- login flows
- module creation & join
- group chat messaging
- private messaging
- authorization edge cases

---

## Testing

### Setup
1. Import collection:
postman/messaging-tests.postman_collection.json
2. Set: 
baseUrl = http://localhost:3000 
---

### Test Flow
Run in order:
1. Login users
2. Create module
3. Join module
4. Inbox requests (automatically populates chat IDs)
5. Send & fetch group messages
6. Create private conversation
7. Send & fetch private messages

---

### Verified Behavior
- Group chats:
- Coach / Athlete / Parent chats correctly isolated
- Private chats:
- only participants can access (403 for others)
- Messaging:
- send & fetch working across all conversation types
- Authorization:
- enforced at conversation level
- No sensitive data exposed in responses

---