### PR TITLE
Feat/messaging frontend

### DIFF
--- a/packages/backend/src/controllers/conversation.controller.ts
+++ b/packages/backend/src/controllers/conversation.controller.ts
@@ -10,12 +10,13 @@ import {
 export async function getUserInboxPreviewsController(req: Request, res: Response) {
     try {
         const userId = req.user?.userId;
+        const moduleId = req.query.moduleId as string | undefined;
 
         if (!userId) {
             return res.status(401).json({ error: "Unauthorized" });
         }
 
-        const previews = await getUserInboxPreviews(userId);
+        const previews = await getUserInboxPreviews(userId, moduleId);
 
         return res.status(200).json({ previews });
     } catch (error) {

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -18,9 +18,10 @@ export async function createGroupConversation(moduleId: string, name: string, me
     });
 }
 
-export async function getUserInboxPreviews(userId: string) {
+export async function getUserInboxPreviews(userId: string, moduleId?: string) {
     const conversations = await prisma.conversation.findMany({
         where: {
+            ...(moduleId ? { moduleId } : {}),
             members: {
                 some: {
                     userId,

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import AgendaDetail from './pages/AgendaDetail'
 import EditAnnouncement from './pages/EditAnnouncement'
 import EditAgenda from './pages/EditAgenda'
 import ModuleAttendanceScreen from './pages/ModuleAttendanceScreen'
+import Messaging from './pages/Inbox'
 
 function CalendarRoute() {
   const { role } = useAuth();
@@ -57,6 +58,7 @@ export default function App() {
         <Route path="/modules/:id/agendas/:agendaId/edit" element={<EditAgenda />} />
         <Route path="/modules/:id/agendas/:agendaId" element={<AgendaDetail />} />
         <Route path="/modules/:id/agendas/:agendaId/edit" element={<EditAgenda />} />
+        <Route path="/modules/:id/messaging" element={<Messaging />} />
       </Routes>
     </BrowserRouter>
   )

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -23,6 +23,11 @@ import EditAnnouncement from './pages/EditAnnouncement'
 import EditAgenda from './pages/EditAgenda'
 import ModuleAttendanceScreen from './pages/ModuleAttendanceScreen'
 import Messaging from './pages/Inbox'
+import ConversationDetail from './pages/ConversationDetail'
+import NewMessage from './pages/NewMessage'
+
+
+
 
 function CalendarRoute() {
   const { role } = useAuth();
@@ -59,6 +64,10 @@ export default function App() {
         <Route path="/modules/:id/agendas/:agendaId" element={<AgendaDetail />} />
         <Route path="/modules/:id/agendas/:agendaId/edit" element={<EditAgenda />} />
         <Route path="/modules/:id/messaging" element={<Messaging />} />
+        <Route path="/modules/:id/messages/:conversationId" element={<ConversationDetail />} />
+        <Route path="/modules/:id/messages/new" element={<NewMessage />} />
+
+
       </Routes>
     </BrowserRouter>
   )

--- a/packages/frontend/src/components/BottomNav.tsx
+++ b/packages/frontend/src/components/BottomNav.tsx
@@ -160,7 +160,7 @@ const tabs: Array<{
   {
     key: 'messaging',
     label: 'Messaging',
-    enabled: false,
+    enabled: true,
     getPath: (moduleId) => `/modules/${moduleId}/messaging`,
   },
 ]

--- a/packages/frontend/src/pages/ConversationDetail.tsx
+++ b/packages/frontend/src/pages/ConversationDetail.tsx
@@ -1,0 +1,227 @@
+import { useState, useEffect, useRef } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useAuth } from '../context/AuthContext';
+import { api } from '../utils/api';
+import BottomNav from '../components/BottomNav'
+
+interface Message {
+  id: string
+  conversationId: string
+  senderId: string
+  content: string
+  isRead: boolean
+  createdAt: string
+  sender: {
+    id: string
+    username: string
+    firstName: string
+    lastName: string
+    role: string
+    profilePicture: string | null
+  }
+}
+
+export default function ConversationDetail() {
+  const { id: moduleId, conversationId } = useParams<{ id: string; conversationId: string }>()
+  const navigate = useNavigate()
+  const { token } = useAuth()
+
+  const [messages, setMessages] = useState<Message[]>([])
+  const [conversationName, setConversationName] = useState('Chat')
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [sending, setSending] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const currentUserId = token
+    ? JSON.parse(atob(token.split('.')[1])).userId
+    : null
+
+  // Fetch conversation name
+  useEffect(() => {
+    if (!token) return
+    api<{ previews: { id: string; name: string | null; isGroup: boolean; members: { id: string; firstName: string; lastName: string }[] }[] }>('/conversations', { token })
+      .then(data => {
+        const conv = data.previews.find(p => p.id === conversationId)
+        if (conv) {
+          if (conv.name) {
+            setConversationName(conv.name)
+          } else {
+            // private chat — show the other person's name
+            const other = conv.members.find(m => m.id !== currentUserId)
+            if (other) setConversationName(`${other.firstName} ${other.lastName}`)
+          }
+        }
+      })
+      .catch(() => {})
+  }, [token, conversationId, currentUserId])
+
+  // Fetch messages
+  useEffect(() => {
+    if (!token || !conversationId) return
+    api<{ messages: Message[] }>(`/conversations/${conversationId}/messages`, { token })
+      .then(data => setMessages(data.messages))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [token, conversationId])
+
+  // Poll for new messages every 3 seconds
+  useEffect(() => {
+    if (!token || !conversationId) return
+    const interval = setInterval(() => {
+      api<{ messages: Message[] }>(`/conversations/${conversationId}/messages`, { token })
+        .then(data => setMessages(data.messages))
+        .catch(() => {})
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [token, conversationId])
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  async function handleSend() {
+    if (!content.trim() || sending) return
+    setSending(true)
+    try {
+      const data = await api<{ data: Message }>(`/conversations/${conversationId}/message`, {
+        method: 'POST',
+        token: token ?? undefined,
+        body: { content },
+      })
+      setMessages(prev => [...prev, data.data])
+      setContent('')
+    } catch {
+      // handle error silently
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const formatTime = (dateStr: string) =>
+    new Date(dateStr).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div
+        style={{
+          fontFamily: "'Amiko', sans-serif",
+          width: '440px',
+          height: '956px',
+          borderRadius: '55px',
+          overflow: 'hidden',
+          background: '#FFFFFF',
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
+
+        {/* Header */}
+        <div className="relative flex items-center justify-center px-6 pt-10 pb-6 border-b border-gray-100 flex-shrink-0">
+          <button
+            className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
+            onClick={() => navigate(`/modules/${moduleId}/messaging`)}
+          >‹</button>
+          <h1 className="text-2xl font-bold text-[#222b45]">{conversationName}</h1>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-6 py-4" style={{ paddingBottom: '100px' }}>
+          {loading && (
+            <p className="text-center text-sm text-[#8f9bb3] mt-8">Loading...</p>
+          )}
+
+          {!loading && messages.length === 0 && (
+            <p className="text-center text-sm text-[#8f9bb3] mt-8">No messages yet. Say hello!</p>
+          )}
+
+          <div className="flex flex-col gap-3">
+            {messages.map(msg => {
+              const isMe = msg.senderId === currentUserId
+              return (
+                <div
+                  key={msg.id}
+                  className={`flex flex-col ${isMe ? 'items-end' : 'items-start'}`}
+                >
+                  {/* Sender name for others */}
+                  {!isMe && (
+                    <span className="text-xs text-[#8f9bb3] mb-1 pl-1">
+                      {msg.sender.firstName} {msg.sender.lastName}
+                    </span>
+                  )}
+
+                  {/* Bubble */}
+                  <div
+                    style={{
+                      maxWidth: '75%',
+                      background: isMe ? '#6166DB' : '#F0F0F8',
+                      borderRadius: isMe ? '18px 18px 4px 18px' : '18px 18px 18px 4px',
+                      padding: '10px 14px',
+                    }}
+                  >
+                    <p style={{
+                      fontFamily: 'Amiko', fontSize: '14px',
+                      color: isMe ? '#FFFFFF' : '#222B45',
+                      margin: 0, lineHeight: '20px',
+                    }}>
+                      {msg.content}
+                    </p>
+                  </div>
+
+                  {/* Timestamp */}
+                  <span className="text-xs text-[#8f9bb3] mt-1 px-1">
+                    {formatTime(msg.createdAt)}
+                  </span>
+                </div>
+              )
+            })}
+            <div ref={bottomRef} />
+          </div>
+        </div>
+
+        {/* Input */}
+        <div
+          className="flex items-center gap-3 px-6 py-4 border-t border-gray-100 flex-shrink-0"
+          style={{ background: '#FFFFFF', position: 'sticky', bottom: '95px', left: 0, right: 0 }}
+        >
+          <input
+            value={content}
+            onChange={e => setContent(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && !e.shiftKey && handleSend()}
+            placeholder="Type a message..."
+            style={{
+              flex: 1, height: '44px',
+              background: '#F0F0F8',
+              borderRadius: '22px',
+              border: 'none', outline: 'none',
+              padding: '0 16px',
+              fontFamily: 'Amiko', fontSize: '14px', color: '#222B45',
+            }}
+          />
+          <button
+            onClick={handleSend}
+            disabled={sending || !content.trim()}
+            style={{
+              width: '44px', height: '44px', borderRadius: '50%',
+              background: content.trim() ? '#6166DB' : '#E0E0E0',
+              border: 'none',
+              cursor: content.trim() ? 'pointer' : 'default',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flexShrink: 0, transition: 'background 0.2s',
+            }}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+              <path d="M22 2L11 13" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M22 2L15 22L11 13L2 9L22 2Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+        </div>
+
+        <BottomNav />
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/ConversationDetail.tsx
+++ b/packages/frontend/src/pages/ConversationDetail.tsx
@@ -120,7 +120,7 @@ export default function ConversationDetail() {
         <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
 
         {/* Header */}
-        <div className="relative flex items-center justify-center px-6 pt-10 pb-6 border-b border-gray-100 flex-shrink-0">
+        <div className="relative flex items-center justify-center px-6 pt-16 pb-6 border-b border-gray-100 flex-shrink-0">
           <button
             className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
             onClick={() => navigate(`/modules/${moduleId}/messaging`)}

--- a/packages/frontend/src/pages/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox.tsx
@@ -1,87 +1,151 @@
-import { useState , useEffect} from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from '../context/AuthContext';
 import { api } from '../utils/api';
 import BottomNav from '../components/BottomNav'
 
-interface Message {
-    id: string,
-    senderName: string,
-    preview: string,
-    sentAt: string,
-    read: boolean
+interface Conversation {
+  id: string
+  name: string
+  isGroup: boolean
+  latestMessage: string | null
+  latestMessageTime: string | null
+  moduleId?: string
+  members: { id: string; firstName: string; lastName: string }[]
 }
 
-export default function Messaging()
-{
-    const { moduleId } = useParams()
-    const navigate = useNavigate()
-    const [messages, sentMessages] = useState<Message[]>([{ 
-        id: '1', senderName: 'John Doe', preview: 'Hey, practice is at 5pm...', sentAt: '2026-04-07T12:00:00Z', read: false },
-        { id: '2', senderName: 'Jane Smith', preview: 'Can you send the schedule?', sentAt: '2026-04-06T09:00:00Z', read: true },
-])
-    const sortedMessages = [...messages].sort(
-        (a, b) => new Date(b.sentAt).getTime() - new Date(a.sentAt).getTime()
-    )
-    const { token } = useAuth()
+export default function Messaging() {
+  const { id: moduleId } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { token } = useAuth()
 
+  const [conversations, setConversations] = useState<Conversation[]>([])
 
-    return (
-        <div className="flex items-center justify-center min-h-screen bg-gray-100">
-            <div 
+  useEffect(() => {
+    if (!token) return
+    api<{ previews: Conversation[] }>(`/conversations?moduleId=${moduleId}`, { token })
+      .then(data => {
+        console.log('conversations:', data.previews)
+        setConversations(data.previews)})
+      .catch(() => {})
+  }, [token])
+
+  const formatMessageTime = (dateStr: string) => {
+    const date = new Date(dateStr)
+    const now = new Date()
+    const yesterday = new Date(now)
+    yesterday.setDate(yesterday.getDate() - 1)
+  
+    if (date.toDateString() === now.toDateString()) {
+      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+    } else if (date.toDateString() === yesterday.toDateString()) {
+      return 'Yesterday'
+    } else {
+      return date.toLocaleDateString()
+    }
+  }
+
+  const sortedConversations = [...conversations]
+  .filter(conv => conv.isGroup || (conv.latestMessage !== null && (!conv.moduleId || conv.moduleId === moduleId)))
+  .sort((a, b) => {
+    if (!a.latestMessageTime) return 1
+    if (!b.latestMessageTime) return -1
+    return new Date(b.latestMessageTime).getTime() - new Date(a.latestMessageTime).getTime()
+  })
+
+  const currentUserId = token
+  ? JSON.parse(atob(token.split('.')[1])).userId
+  : null
+
+  const getConversationName = (conv: Conversation) => {
+  if (conv.name) return conv.name
+  const other = conv.members.find(m => m.id !== currentUserId)
+  return other ? `${other.firstName} ${other.lastName}` : 'Unknown'
+}
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div
+        style={{
+          fontFamily: "'Amiko', sans-serif",
+          width: '440px',
+          height: '956px',
+          borderRadius: '55px',
+          overflow: 'hidden',
+          background: '#FFFFFF',
+          position: 'relative',
+        }}
+        className="mx-auto flex flex-col"
+      >
+        <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
+
+        {/* Header */}
+        <div className="relative flex items-center justify-center px-6 pt-10 pb-10">
+          <button
+            className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
+            onClick={() => window.history.back()}
+          >‹</button>
+          <h1 className="text-4xl font-bold text-[#222b45]">Inbox</h1>
+          <button
+            onClick={() => navigate(`/modules/${moduleId}/messages/new`)}
             style={{
-                fontFamily: "'Amiko', sans-serif",
-                width: '440px',
-                height: '956px',
-                borderRadius: '55px',
-                overflow: 'hidden',
-                background: '#FFFFFF',
-                position: 'relative',
-              }}
-              className="mx-auto flex flex-col"
-                >
-                <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
-
-                {/* Header */}
-                <div className="relative flex items-center justify-center px-6 pt-10 pb-10">
-                    <button
-                        className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
-                        onClick={() => window.history.back()}
-                    >‹</button>
-                    <h1 className="text-4xl font-bold text-[#222b45]">Inbox</h1>
-                </div>
-                {/* New Message */}
-                <div className="flex-1 px-6 overflow-y-auto">
-                    {sortedMessages.map(msg => (
-                        <div
-                        key={msg.id}
-                        onClick={() => navigate('/modules/${moduleId}/messages/${msg.id}')}
-                        className="flex items-center gap-5 py-6 border-b border-gray-100 cursor-pointer">
-                        {/* unread dot */}
-                        {!msg.read && (<div className="w-2 h-2 rounded-full bg-[#6166db] flex-shrink-0" />)}
-                        {msg.read && <div className="w-2 h-2 flex-shrink-0" />}
-
-                        {/* Content */}
-                        <div className="flex-1">
-                            <div className="flex justify-between">
-                                <span className={`text-sm ${!msg.read ? 'font-bold test-[#222b45]' : 'font-normal test-[#222b45]'}`}>
-                                    {msg.senderName}
-                                </span>
-                                <span className="text-xs text-[#8f9bb3]">
-                                    {new Date(msg.sentAt).toLocaleDateString()}
-                                </span>
-                            </div>
-                            <p className={`text-xs mt-0.5 truncate ${!msg.read ? 'text-[#222b45] font-semibold' : 'text-[#8f9bb3]'}`}>
-                                {msg.preview}
-                            </p>
-                        </div>
-                        </div>
-                    ))}
-                </div>
-                {/* Recent Messages */}
-                <BottomNav/>
+                width: '36px', height: '36px', borderRadius: '50%',
+                background: '#B8E466', border: 'none', cursor: 'pointer',
+                boxShadow: '0px 4px 4px rgba(0,0,0,0.25)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                position: 'absolute', right: '24px',
+            }}
+            >
+            <div style={{ position: 'relative', width: '16px', height: '16px' }}>
+                <div style={{ position: 'absolute', left: '7px', top: 0, width: '2px', height: '16px', background: '#FFFFFF' }} />
+                <div style={{ position: 'absolute', top: '7px', left: 0, width: '16px', height: '2px', background: '#FFFFFF' }} />
             </div>
+            </button>
         </div>
-    )
 
+        {/* Conversation List */}
+        <div className="flex-1 px-6 overflow-y-auto">
+          {conversations.length === 0 && (
+            <p className="text-center text-sm text-[#8f9bb3] mt-8">No conversations yet</p>
+          )}
+
+          {sortedConversations.map(conv => (
+            <div
+              key={conv.id}
+              onClick={() => navigate(`/modules/${moduleId}/messages/${conv.id}`)}
+              className="flex items-center gap-5 py-6 border-b border-gray-100 cursor-pointer"
+            >
+              {/* Unread dot */}
+              {conv.latestMessage
+                ? <div className="w-2 h-2 rounded-full bg-[#6166db] flex-shrink-0" />
+                : <div className="w-2 h-2 flex-shrink-0" />
+              }
+
+              {/* Content */}
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-[#222b45]">
+                    {getConversationName(conv)}
+                  </span>
+                  {conv.latestMessageTime && (
+                    <span className="text-xs text-[#8f9bb3]">
+                      {formatMessageTime(conv.latestMessageTime)}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs mt-0.5 truncate text-[#8f9bb3]">
+                  {conv.latestMessage ?? 'No messages yet'}
+                </p>
+              </div>
+              <svg width="8" height="14" viewBox="0 0 8 14" fill="none">
+                <path d="M1 1L7 7L1 13" stroke="#CED3DE" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </div>
+          ))}
+        </div>
+
+        <BottomNav />
+      </div>
+    </div>
+  )
 }

--- a/packages/frontend/src/pages/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox.tsx
@@ -1,0 +1,87 @@
+import { useState , useEffect} from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useAuth } from '../context/AuthContext';
+import { api } from '../utils/api';
+import BottomNav from '../components/BottomNav'
+
+interface Message {
+    id: string,
+    senderName: string,
+    preview: string,
+    sentAt: string,
+    read: boolean
+}
+
+export default function Messaging()
+{
+    const { moduleId } = useParams()
+    const navigate = useNavigate()
+    const [messages, sentMessages] = useState<Message[]>([{ 
+        id: '1', senderName: 'John Doe', preview: 'Hey, practice is at 5pm...', sentAt: '2026-04-07T12:00:00Z', read: false },
+        { id: '2', senderName: 'Jane Smith', preview: 'Can you send the schedule?', sentAt: '2026-04-06T09:00:00Z', read: true },
+])
+    const sortedMessages = [...messages].sort(
+        (a, b) => new Date(b.sentAt).getTime() - new Date(a.sentAt).getTime()
+    )
+    const { token } = useAuth()
+
+
+    return (
+        <div className="flex items-center justify-center min-h-screen bg-gray-100">
+            <div 
+            style={{
+                fontFamily: "'Amiko', sans-serif",
+                width: '440px',
+                height: '956px',
+                borderRadius: '55px',
+                overflow: 'hidden',
+                background: '#FFFFFF',
+                position: 'relative',
+              }}
+              className="mx-auto flex flex-col"
+                >
+                <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
+
+                {/* Header */}
+                <div className="relative flex items-center justify-center px-6 pt-10 pb-10">
+                    <button
+                        className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
+                        onClick={() => window.history.back()}
+                    >‹</button>
+                    <h1 className="text-4xl font-bold text-[#222b45]">Inbox</h1>
+                </div>
+                {/* New Message */}
+                <div className="flex-1 px-6 overflow-y-auto">
+                    {sortedMessages.map(msg => (
+                        <div
+                        key={msg.id}
+                        onClick={() => navigate('/modules/${moduleId}/messages/${msg.id}')}
+                        className="flex items-center gap-5 py-6 border-b border-gray-100 cursor-pointer">
+                        {/* unread dot */}
+                        {!msg.read && (<div className="w-2 h-2 rounded-full bg-[#6166db] flex-shrink-0" />)}
+                        {msg.read && <div className="w-2 h-2 flex-shrink-0" />}
+
+                        {/* Content */}
+                        <div className="flex-1">
+                            <div className="flex justify-between">
+                                <span className={`text-sm ${!msg.read ? 'font-bold test-[#222b45]' : 'font-normal test-[#222b45]'}`}>
+                                    {msg.senderName}
+                                </span>
+                                <span className="text-xs text-[#8f9bb3]">
+                                    {new Date(msg.sentAt).toLocaleDateString()}
+                                </span>
+                            </div>
+                            <p className={`text-xs mt-0.5 truncate ${!msg.read ? 'text-[#222b45] font-semibold' : 'text-[#8f9bb3]'}`}>
+                                {msg.preview}
+                            </p>
+                        </div>
+                        </div>
+                    ))}
+                </div>
+                {/* Recent Messages */}
+                <BottomNav/>
+            </div>
+        </div>
+    )
+
+}

--- a/packages/frontend/src/pages/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox.tsx
@@ -30,7 +30,7 @@ export default function Messaging() {
         console.log('conversations:', data.previews)
         setConversations(data.previews)})
       .catch(() => {})
-  }, [token])
+  }, [token, moduleId])
 
   const formatMessageTime = (dateStr: string) => {
     const date = new Date(dateStr)

--- a/packages/frontend/src/pages/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox.tsx
@@ -11,6 +11,8 @@ interface Conversation {
   latestMessage: string | null
   latestMessageTime: string | null
   moduleId?: string
+  hasUnread: boolean
+  profilePicture?: string | null
   members: { id: string; firstName: string; lastName: string }[]
 }
 
@@ -80,12 +82,19 @@ export default function Messaging() {
         <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
 
         {/* Header */}
-        <div className="relative flex items-center justify-center px-6 pt-10 pb-10">
+        <div className="relative flex items-center justify-center px-6 pt-16 pb-10">
           <button
             className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
-            onClick={() => window.history.back()}
+            onClick={() => navigate(`/modules/${moduleId}`)}
           >‹</button>
-          <h1 className="text-4xl font-bold text-[#222b45]">Inbox</h1>
+          <h1 style={{
+            fontFamily: 'Amiko',
+            fontWeight: 400,
+            fontSize: '40px',
+            lineHeight: '53px',
+            color: '#000000',
+            margin: 0,
+          }}>Inbox</h1>
           <button
             onClick={() => navigate(`/modules/${moduleId}/messages/new`)}
             style={{
@@ -116,15 +125,30 @@ export default function Messaging() {
               className="flex items-center gap-5 py-6 border-b border-gray-100 cursor-pointer"
             >
               {/* Unread dot */}
-              {conv.latestMessage
+              {conv.hasUnread
                 ? <div className="w-2 h-2 rounded-full bg-[#6166db] flex-shrink-0" />
                 : <div className="w-2 h-2 flex-shrink-0" />
               }
 
+              <div style={{
+                width: '44px', height: '44px', borderRadius: '50%',
+                background: '#6166DB', flexShrink: 0,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                overflow: 'hidden',
+                }}>
+                {conv.profilePicture ? (
+                  <img src={conv.profilePicture} alt="avatar" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                  ) : (
+                  <span style={{ fontFamily: 'Amiko', fontSize: '16px', color: '#FFFFFF', fontWeight: 700 }}>
+                    {getConversationName(conv).charAt(0).toUpperCase()}
+                  </span>
+                  )}
+              </div>
+
               {/* Content */}
               <div className="flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-bold text-[#222b45]">
+                  <span className="text-base font-bold text-[#222b45]">
                     {getConversationName(conv)}
                   </span>
                   {conv.latestMessageTime && (
@@ -133,7 +157,7 @@ export default function Messaging() {
                     </span>
                   )}
                 </div>
-                <p className="text-xs mt-0.5 truncate text-[#8f9bb3]">
+                <p className="text-sm mt-0.5 truncate text-[#8f9bb3]">
                   {conv.latestMessage ?? 'No messages yet'}
                 </p>
               </div>

--- a/packages/frontend/src/pages/ModuleDashboard.tsx
+++ b/packages/frontend/src/pages/ModuleDashboard.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { api } from '../utils/api'
 import { useAuth } from '../context/AuthContext'
 import BottomNav from '../components/BottomNav'
+import React from 'react'
 
 const spring = { type: 'spring' as const, stiffness: 100, damping: 14 }
 

--- a/packages/frontend/src/pages/NewMessage.tsx
+++ b/packages/frontend/src/pages/NewMessage.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useAuth } from '../context/AuthContext';
+import { api } from '../utils/api';
+
+interface RosterMember {
+  userId: string
+  name: string
+  role: string
+  email: string
+  profilePicture: string | null
+}
+
+export default function NewMessage() {
+  const { id: moduleId } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { token } = useAuth()
+
+  const [roster, setRoster] = useState<RosterMember[]>([])
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [starting, setStarting] = useState<string | null>(null)
+
+  const currentUserId = token
+    ? JSON.parse(atob(token.split('.')[1])).userId
+    : null
+
+  useEffect(() => {
+    if (!token || !moduleId) return
+    api<{ roster: RosterMember[] }>(`/modules/${moduleId}/roster`, { token })
+      .then(data => setRoster(data.roster))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [token, moduleId])
+
+  const filtered = roster.filter(member =>
+    member.userId !== currentUserId &&
+    member.name.toLowerCase().includes(search.toLowerCase())
+  )
+
+  async function handleSelectMember(otherUserId: string) {
+    if (starting) return
+    setStarting(otherUserId)
+    try {
+      const data = await api<{ conversation: { id: string } }>('/conversations/private', {
+        method: 'POST',
+        token: token ?? undefined,
+        body: { otherUserId, moduleId },
+      })
+      navigate(`/modules/${moduleId}/messages/${data.conversation.id}`)
+    } catch {
+      setStarting(null)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div
+        style={{
+          fontFamily: "'Amiko', sans-serif",
+          width: '440px',
+          height: '956px',
+          borderRadius: '55px',
+          overflow: 'hidden',
+          background: '#FFFFFF',
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <style>{`@import url('https://fonts.googleapis.com/css2?family=Amiko:wght@400;600;700&display=swap');`}</style>
+
+        {/* Header */}
+        <div className="relative flex items-center justify-center px-6 pt-10 pb-6 flex-shrink-0">
+          <button
+            className="absolute left-6 w-9 h-9 bg-gray-100 rounded-xl flex items-center justify-center text-lg text-[#222b45]"
+            onClick={() => navigate(`/modules/${moduleId}/messaging`)}
+          >‹</button>
+          <h1 className="text-3xl font-bold text-[#222b45]">New Message</h1>
+        </div>
+
+        {/* Search */}
+        <div className="px-6 pb-4 flex-shrink-0">
+          <div style={{
+            background: '#F0F0F8', borderRadius: '22px',
+            display: 'flex', alignItems: 'center',
+            padding: '0 16px', height: '44px',
+          }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ marginRight: '8px', flexShrink: 0 }}>
+              <circle cx="11" cy="11" r="8" stroke="#8f9bb3" strokeWidth="2"/>
+              <path d="M21 21L16.65 16.65" stroke="#8f9bb3" strokeWidth="2" strokeLinecap="round"/>
+            </svg>
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search people..."
+              style={{
+                flex: 1, background: 'transparent',
+                border: 'none', outline: 'none',
+                fontFamily: 'Amiko', fontSize: '14px', color: '#222B45',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* To: field */}
+        <div style={{
+        display: 'flex', alignItems: 'center',
+        borderBottom: '1px solid #F0F0F0',
+        padding: '12px 24px',
+        gap: '8px',
+        }}>
+        <span style={{ fontFamily: 'Amiko', fontSize: '14px', color: '#8f9bb3', flexShrink: 0 }}>To:</span>
+        <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Name"
+            autoFocus
+            style={{
+            flex: 1, border: 'none', outline: 'none',
+            fontFamily: 'Amiko', fontSize: '14px', color: '#222B45',
+            background: 'transparent',
+            }}
+        />
+        </div>
+
+        {/* Dropdown results — only show when search has text */}
+        {search.trim() && (
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+            {filtered.length === 0 && (
+            <p style={{ fontFamily: 'Amiko', fontSize: '14px', color: '#BEBEBE', textAlign: 'center', marginTop: '40px' }}>
+                No results
+            </p>
+            )}
+            {filtered.map(member => (
+            <div
+                key={member.userId}
+                onClick={() => handleSelectMember(member.userId)}
+                style={{
+                display: 'flex', alignItems: 'center', gap: '12px',
+                padding: '14px 24px',
+                borderBottom: '1px solid #F0F0F0',
+                cursor: 'pointer',
+                }}
+            >
+                <div style={{
+                width: '40px', height: '40px', borderRadius: '50%',
+                background: '#6166DB',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                flexShrink: 0,
+                }}>
+                <span style={{ fontFamily: 'Amiko', fontSize: '14px', color: '#FFFFFF', fontWeight: 700 }}>
+                    {member.name.charAt(0)}
+                </span>
+                </div>
+                <div>
+                <p style={{ fontFamily: 'Amiko', fontSize: '14px', fontWeight: 700, color: '#222B45', margin: 0 }}>
+                    {member.name}
+                </p>
+                <p style={{ fontFamily: 'Amiko', fontSize: '12px', color: '#8f9bb3', margin: '2px 0 0 0' }}>
+                    {member.role === 'MODULE_ADMIN' ? 'Coach' : 'Member'}
+                </p>
+                </div>
+            </div>
+            ))}
+        </div>
+        )}
+
+{/* Empty state when no search */}
+{!search.trim() && (
+  <p style={{ fontFamily: 'Amiko', fontSize: '14px', color: '#BEBEBE', textAlign: 'center', marginTop: '40px' }}>
+    Start typing a name
+  </p>
+)}
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/NewMessage.tsx
+++ b/packages/frontend/src/pages/NewMessage.tsx
@@ -79,30 +79,6 @@ export default function NewMessage() {
           <h1 className="text-3xl font-bold text-[#222b45]">New Message</h1>
         </div>
 
-        {/* Search */}
-        <div className="px-6 pb-4 flex-shrink-0">
-          <div style={{
-            background: '#F0F0F8', borderRadius: '22px',
-            display: 'flex', alignItems: 'center',
-            padding: '0 16px', height: '44px',
-          }}>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ marginRight: '8px', flexShrink: 0 }}>
-              <circle cx="11" cy="11" r="8" stroke="#8f9bb3" strokeWidth="2"/>
-              <path d="M21 21L16.65 16.65" stroke="#8f9bb3" strokeWidth="2" strokeLinecap="round"/>
-            </svg>
-            <input
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              placeholder="Search people..."
-              style={{
-                flex: 1, background: 'transparent',
-                border: 'none', outline: 'none',
-                fontFamily: 'Amiko', fontSize: '14px', color: '#222B45',
-              }}
-            />
-          </div>
-        </div>
-
         {/* To: field */}
         <div style={{
         display: 'flex', alignItems: 'center',

--- a/packages/frontend/src/pages/NewMessage.tsx
+++ b/packages/frontend/src/pages/NewMessage.tsx
@@ -18,7 +18,6 @@ export default function NewMessage() {
 
   const [roster, setRoster] = useState<RosterMember[]>([])
   const [search, setSearch] = useState('')
-  const [loading, setLoading] = useState(true)
   const [starting, setStarting] = useState<string | null>(null)
 
   const currentUserId = token
@@ -30,7 +29,6 @@ export default function NewMessage() {
     api<{ roster: RosterMember[] }>(`/modules/${moduleId}/roster`, { token })
       .then(data => setRoster(data.roster))
       .catch(() => {})
-      .finally(() => setLoading(false))
   }, [token, moduleId])
 
   const filtered = roster.filter(member =>

--- a/packages/frontend/src/pages/SignupScreen.tsx
+++ b/packages/frontend/src/pages/SignupScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react'
+import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { api } from '../utils/api'


### PR DESCRIPTION
# Feature: Messaging Frontend

## Description
This PR implements the full frontend for the Messaging feature based on the Backend endpoints.

---

## Changes

### Inbox (`Inbox.tsx`)
- Displays all conversations for the current module fetched from `GET /api/conversations?moduleId=:id`
- Conversations sorted by most recent message time
- Shows avatar with the first letter of the conversation name
- shows time if sent today, "Yesterday" if sent yesterday, full date otherwise
- Unread dot indicator using `hasUnread` field from backend
- `+` button in header navigates to New Message page
- Back button navigates to module dashboard

### Conversation Detail (`ConversationDetail.tsx`)
- Full chat view with iMessage-style message bubbles
- Current user's messages on the right in purple, others on the left in grey
- Sender name shown above messages in group chats
- Timestamps shown below each bubble
- Input bar with send button — also submits on Enter key
- Polls for new messages every 3 seconds for a real-time feel
- Auto scrolls to the latest message on load and new messages
- Marks messages as read on open
- Header shows conversation name — private chats show the other person's name

### New Message (`NewMessage.tsx`)
- iMessage-style `To:` field with live search
- Fetches module roster from `GET /api/modules/:id/roster.`
- Results only appear when typing — empty state shows "Start typing a name."
- Members sorted alphabetically
- Excludes the current user from the list
- Tapping a member creates or opens a private conversation via `POST /api/conversations/private` and navigates directly to it

---

## Routing

Added to `App.tsx`:

## Backend Fix
- Updated `getUserInboxPreviews` service to accept an optional `moduleId` parameter
- Updated `getUserInboxPreviewsController` to read `moduleId` from query params and pass it to the service
- This ensures messages are scoped within each module and do not appear in other modules. 