### PR TITLE
feat(progress): goals + routines backend, wire ProgressScreen

### DIFF
--- a/packages/backend/prisma/migrations/20260420034154_add_goals_routines_deductions/migration.sql
+++ b/packages/backend/prisma/migrations/20260420034154_add_goals_routines_deductions/migration.sql
@@ -1,3 +1,6 @@
+-- Drop old Goal table from previous migration (different schema)
+DROP TABLE IF EXISTS "Goal";
+
 -- CreateTable
 CREATE TABLE "Goal" (
     "id" TEXT NOT NULL,

--- a/packages/backend/prisma/migrations/20260420034154_add_goals_routines_deductions/migration.sql
+++ b/packages/backend/prisma/migrations/20260420034154_add_goals_routines_deductions/migration.sql
@@ -1,0 +1,71 @@
+-- CreateTable
+CREATE TABLE "Goal" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "completed" BOOLEAN NOT NULL DEFAULT false,
+    "moduleId" TEXT NOT NULL,
+    "athleteId" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Goal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Routine" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "notes" TEXT,
+    "moduleId" TEXT NOT NULL,
+    "athleteId" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Routine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Deduction" (
+    "id" TEXT NOT NULL,
+    "routineId" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Deduction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Goal_moduleId_athleteId_idx" ON "Goal"("moduleId", "athleteId");
+
+-- CreateIndex
+CREATE INDEX "Routine_moduleId_athleteId_date_idx" ON "Routine"("moduleId", "athleteId", "date");
+
+-- CreateIndex
+CREATE INDEX "Deduction_routineId_idx" ON "Deduction"("routineId");
+
+-- AddForeignKey
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_athleteId_fkey" FOREIGN KEY ("athleteId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Routine" ADD CONSTRAINT "Routine_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Routine" ADD CONSTRAINT "Routine_athleteId_fkey" FOREIGN KEY ("athleteId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Routine" ADD CONSTRAINT "Routine_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Deduction" ADD CONSTRAINT "Deduction_routineId_fkey" FOREIGN KEY ("routineId") REFERENCES "Routine"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -35,33 +35,37 @@ enum ModuleType {
 }
 
 model User {
-  id                        String               @id @default(cuid())
-  email                     String               @unique
-  username                  String               @unique
-  firstName                 String
-  lastName                  String
-  dob                       DateTime
-  password                  String
-  role                      Role                 @default(ATHLETE)
-  emailVerified             Boolean              @default(false)
-  verificationToken         String?
-  profilePicture            String?
-  createdAt                 DateTime             @default(now())
-  updatedAt                 DateTime             @updatedAt
+  id                String   @id @default(cuid())
+  email             String   @unique
+  username          String   @unique
+  firstName         String
+  lastName          String
+  dob               DateTime
+  password          String
+  role              Role     @default(ATHLETE)
+  emailVerified     Boolean  @default(false)
+  verificationToken String?
+  profilePicture    String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
-  memberships               Membership[]
-  conversationMemberships   ConversationMember[]
-  readReceipts              MessageRead[]
-  sentMessages              Message[]            @relation("SentMessages")
-  createdModules            Module[]             @relation("CreatedModules")
-  moduleMemberships         ModuleMembership[]
-  attendanceRecords         Attendance[]         @relation("AttendanceMember")
-  markedAttendances         Attendance[]         @relation("AttendanceMarkedBy")
-  createdEvents             Event[]              @relation("CreatedEvents")
-  announcements             Announcement[]
-  announcementLikes         AnnouncementLike[]
-  agendas                   Agenda[]
-  agendaLikes               AgendaLike[]
+  memberships             Membership[]
+  conversationMemberships ConversationMember[]
+  readReceipts            MessageRead[]
+  sentMessages            Message[]            @relation("SentMessages")
+  createdModules          Module[]             @relation("CreatedModules")
+  moduleMemberships       ModuleMembership[]
+  attendanceRecords       Attendance[]         @relation("AttendanceMember")
+  markedAttendances       Attendance[]         @relation("AttendanceMarkedBy")
+  createdEvents           Event[]              @relation("CreatedEvents")
+  announcements           Announcement[]
+  announcementLikes       AnnouncementLike[]
+  agendas                 Agenda[]
+  agendaLikes             AgendaLike[]
+  assignedGoals           Goal[]               @relation("AthleteGoals")
+  createdGoals            Goal[]               @relation("CreatedGoals")
+  athleteRoutines         Routine[]            @relation("AthleteRoutines")
+  createdRoutines         Routine[]            @relation("CreatedRoutines")
 }
 
 model Gym {
@@ -70,18 +74,18 @@ model Gym {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  teams     Team[]
+  teams Team[]
 }
 
 model Team {
-  id        String       @id @default(cuid())
+  id        String   @id @default(cuid())
   name      String
   gymId     String
-  createdAt DateTime     @default(now())
-  updatedAt DateTime     @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  gym       Gym          @relation(fields: [gymId], references: [id], onDelete: Cascade)
-  members   Membership[]
+  gym     Gym          @relation(fields: [gymId], references: [id], onDelete: Cascade)
+  members Membership[]
 }
 
 model Membership {
@@ -92,32 +96,34 @@ model Membership {
   createdAt  DateTime   @default(now())
   updatedAt  DateTime   @updatedAt
 
-  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  team       Team       @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
   @@unique([userId, teamId])
 }
 
 model Module {
-  id              String             @id @default(cuid())
+  id              String     @id @default(cuid())
   name            String
   description     String?
-  joinCode        String             @unique
-  type            ModuleType         @default(CUSTOM)
-  systemKey       String?            @unique
+  joinCode        String     @unique
+  type            ModuleType @default(CUSTOM)
+  systemKey       String?    @unique
   createdById     String?
   enrollmentStart DateTime?
   enrollmentEnd   DateTime?
-  createdAt       DateTime           @default(now())
-  updatedAt       DateTime           @updatedAt
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
 
-  createdBy       User?              @relation("CreatedModules", fields: [createdById], references: [id], onDelete: SetNull)
-  attendances     Attendance[]
-  conversations   Conversation[]
-  memberships     ModuleMembership[]
-  events          Event[]
-  announcements   Announcement[]
-  agendas         Agenda[]
+  createdBy     User?              @relation("CreatedModules", fields: [createdById], references: [id], onDelete: SetNull)
+  attendances   Attendance[]
+  conversations Conversation[]
+  memberships   ModuleMembership[]
+  events        Event[]
+  announcements Announcement[]
+  agendas       Agenda[]
+  goals         Goal[]
+  routines      Routine[]
 }
 
 model ModuleMembership {
@@ -128,25 +134,25 @@ model ModuleMembership {
   createdAt  DateTime         @default(now())
   updatedAt  DateTime         @updatedAt
 
-  user       User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-  module     Module           @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  module Module @relation(fields: [moduleId], references: [id], onDelete: Cascade)
 
   @@unique([userId, moduleId])
 }
 
 model Attendance {
-  id          String            @id @default(cuid())
-  moduleId    String
-  memberId    String
-  markedById  String
-  date        DateTime
-  status      AttendanceStatus
-  createdAt   DateTime          @default(now())
-  updatedAt   DateTime          @updatedAt
+  id         String           @id @default(cuid())
+  moduleId   String
+  memberId   String
+  markedById String
+  date       DateTime
+  status     AttendanceStatus
+  createdAt  DateTime         @default(now())
+  updatedAt  DateTime         @updatedAt
 
-  module      Module            @relation(fields: [moduleId], references: [id], onDelete: Cascade)
-  member      User              @relation("AttendanceMember", fields: [memberId], references: [id], onDelete: Cascade)
-  markedBy    User              @relation("AttendanceMarkedBy", fields: [markedById], references: [id], onDelete: Restrict)
+  module   Module @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  member   User   @relation("AttendanceMember", fields: [memberId], references: [id], onDelete: Cascade)
+  markedBy User   @relation("AttendanceMarkedBy", fields: [markedById], references: [id], onDelete: Restrict)
 
   @@unique([moduleId, memberId, date])
   @@index([moduleId, date])
@@ -154,20 +160,20 @@ model Attendance {
 }
 
 model Event {
-  id          String    @id @default(cuid())
+  id          String   @id @default(cuid())
   title       String
   date        DateTime
   startTime   String?
   endTime     String?
-  allDay      Boolean   @default(false)
+  allDay      Boolean  @default(false)
   description String?
   moduleId    String
   createdById String
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  module      Module    @relation(fields: [moduleId], references: [id], onDelete: Cascade)
-  createdBy   User      @relation("CreatedEvents", fields: [createdById], references: [id], onDelete: Cascade)
+  module    Module @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  createdBy User   @relation("CreatedEvents", fields: [createdById], references: [id], onDelete: Cascade)
 }
 
 model Announcement {
@@ -179,36 +185,36 @@ model Announcement {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  module    Module             @relation(fields: [moduleId], references: [id], onDelete: Cascade)
-  author    User               @relation(fields: [authorId], references: [id], onDelete: Cascade)
-  likes     AnnouncementLike[]
+  module Module             @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  author User               @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  likes  AnnouncementLike[]
 }
 
 model AnnouncementLike {
-  id             String       @id @default(cuid())
+  id             String   @id @default(cuid())
   userId         String
   announcementId String
-  createdAt      DateTime     @default(now())
+  createdAt      DateTime @default(now())
 
-  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
-  announcement   Announcement @relation(fields: [announcementId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  announcement Announcement @relation(fields: [announcementId], references: [id], onDelete: Cascade)
 
   @@unique([userId, announcementId])
 }
 
 model Agenda {
-  id          String       @id @default(cuid())
+  id          String   @id @default(cuid())
   title       String
   description String?
   date        DateTime
   moduleId    String
   authorId    String
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
-  module      Module       @relation(fields: [moduleId], references: [id], onDelete: Cascade)
-  author      User         @relation(fields: [authorId], references: [id], onDelete: Cascade)
-  likes       AgendaLike[]
+  module Module       @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  author User         @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  likes  AgendaLike[]
 }
 
 model AgendaLike {
@@ -217,48 +223,49 @@ model AgendaLike {
   agendaId  String
   createdAt DateTime @default(now())
 
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  agenda    Agenda   @relation(fields: [agendaId], references: [id], onDelete: Cascade)
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  agenda Agenda @relation(fields: [agendaId], references: [id], onDelete: Cascade)
 
   @@unique([userId, agendaId])
 }
 
 model Conversation {
-  id        String    @id @default(cuid())
-  name      String?
-  isGroup   Boolean   @default(false)
-  moduleId  String?
+  id       String  @id @default(cuid())
+  name     String?
+  isGroup  Boolean @default(false)
+  moduleId String?
 
-  module    Module?   @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  module    Module?              @relation(fields: [moduleId], references: [id], onDelete: Cascade)
   members   ConversationMember[]
   messages  Message[]
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
 }
 
 model ConversationMember {
-  id                String        @id @default(cuid())
-  conversationId    String
-  userId            String
-  conversation      Conversation  @relation(fields: [conversationId], references: [id], onDelete: Cascade)
-  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id             String       @id @default(cuid())
+  conversationId String
+  userId         String
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  createdAt         DateTime      @default(now())
-  @@unique([conversationId, userId]) 
+  createdAt DateTime @default(now())
+
+  @@unique([conversationId, userId])
 }
 
 model Message {
-  id                String        @id @default(cuid())
-  conversationId    String
-  senderId          String
-  content           String
-  isRead            Boolean       @default(false)
-  
-  readReceipts      MessageRead[]
-  conversation      Conversation  @relation(fields: [conversationId], references: [id], onDelete: Cascade)
-  sender            User          @relation("SentMessages", fields: [senderId], references: [id], onDelete: Cascade)
-  createdAt         DateTime      @default(now())      
-  updatedAt         DateTime      @updatedAt
+  id             String  @id @default(cuid())
+  conversationId String
+  senderId       String
+  content        String
+  isRead         Boolean @default(false)
+
+  readReceipts MessageRead[]
+  conversation Conversation  @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  sender       User          @relation("SentMessages", fields: [senderId], references: [id], onDelete: Cascade)
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
 }
 
 model MessageRead {
@@ -267,8 +274,58 @@ model MessageRead {
   userId    String
   readAt    DateTime @default(now())
 
-  message   Message  @relation(fields: [messageId], references: [id], onDelete: Cascade)
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([messageId, userId])
+}
+
+model Goal {
+  id          String   @id @default(cuid())
+  title       String
+  completed   Boolean  @default(false)
+  moduleId    String
+  athleteId   String
+  createdById String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  module    Module @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  athlete   User   @relation("AthleteGoals", fields: [athleteId], references: [id], onDelete: Cascade)
+  createdBy User   @relation("CreatedGoals", fields: [createdById], references: [id], onDelete: Cascade)
+
+  @@index([moduleId, athleteId])
+}
+
+model Routine {
+  id          String   @id @default(cuid())
+  title       String
+  date        DateTime
+  notes       String?
+  moduleId    String
+  athleteId   String
+  createdById String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  module     Module      @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  athlete    User        @relation("AthleteRoutines", fields: [athleteId], references: [id], onDelete: Cascade)
+  createdBy  User        @relation("CreatedRoutines", fields: [createdById], references: [id], onDelete: Cascade)
+  deductions Deduction[]
+
+  @@index([moduleId, athleteId, date])
+}
+
+model Deduction {
+  id        String   @id @default(cuid())
+  routineId String
+  category  String
+  value     Float
+  notes     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  routine Routine @relation(fields: [routineId], references: [id], onDelete: Cascade)
+
+  @@index([routineId])
 }

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -9,6 +9,8 @@ import eventsRoutes from "./routes/events.routes";
 import announcementsRoutes from "./routes/announcements.routes";
 import agendasRoutes from "./routes/agenda.routes";
 import conversationRoutes from "./routes/conversation.routes";
+import { goalsModuleRouter, goalsByIdRouter } from "./routes/goals.routes";
+import { routinesModuleRouter, routinesByIdRouter } from "./routes/routines.routes";
 
 /* Express App */
 const app = express();
@@ -25,6 +27,10 @@ app.use("/api/modules", attendanceRoutes);
 app.use("/api/events", eventsRoutes);
 app.use("/api/modules/:moduleId/announcements", announcementsRoutes);
 app.use("/api/modules/:moduleId/agendas", agendasRoutes);
+app.use("/api/modules/:moduleId/goals", goalsModuleRouter);
+app.use("/api/modules/:moduleId/routines", routinesModuleRouter);
+app.use("/api/goals", goalsByIdRouter);
+app.use("/api/routines", routinesByIdRouter);
 app.use("/api/conversations", conversationRoutes);
 
 export default app;

--- a/packages/backend/src/controllers/goals.controller.ts
+++ b/packages/backend/src/controllers/goals.controller.ts
@@ -1,0 +1,80 @@
+import { Request, Response } from "express";
+import {
+  listGoals,
+  createGoal,
+  updateGoal,
+  deleteGoal,
+} from "../services/goals.service";
+import { validateCreateGoal, validateUpdateGoal } from "../validators/goals.validator";
+
+function handleError(res: Response, error: unknown, context: string) {
+  const message = error instanceof Error ? error.message : "Internal server error";
+
+  if (message === "Goal not found") return res.status(404).json({ error: message });
+  if (
+    message === "Not a member of this module" ||
+    message === "Not authorized" ||
+    message === "Athlete is not a member of this module"
+  ) {
+    return res.status(403).json({ error: message });
+  }
+
+  console.error(`${context} error:`, error);
+  return res.status(500).json({ error: "Internal server error" });
+}
+
+export async function listGoalsController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const { moduleId } = req.params;
+    if (!moduleId) return res.status(400).json({ error: "Module ID is required" });
+
+    const athleteIdFilter = typeof req.query.athleteId === "string" ? req.query.athleteId : undefined;
+
+    const goals = await listGoals(req.user.userId, moduleId as string, athleteIdFilter);
+    return res.status(200).json(goals);
+  } catch (error) {
+    return handleError(res, error, "List goals");
+  }
+}
+
+export async function createGoalController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const { moduleId } = req.params;
+    if (!moduleId) return res.status(400).json({ error: "Module ID is required" });
+
+    const { title, athleteId } = validateCreateGoal(req.body);
+
+    const goal = await createGoal(req.user.userId, moduleId as string, athleteId, title);
+    return res.status(201).json({ message: "Goal created successfully", goal });
+  } catch (error) {
+    return handleError(res, error, "Create goal");
+  }
+}
+
+export async function updateGoalController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const data = validateUpdateGoal(req.body);
+    const goal = await updateGoal(req.user.userId, req.params.id as string, data);
+
+    return res.status(200).json({ message: "Goal updated successfully", goal });
+  } catch (error) {
+    return handleError(res, error, "Update goal");
+  }
+}
+
+export async function deleteGoalController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    await deleteGoal(req.user.userId, req.params.id as string);
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    return handleError(res, error, "Delete goal");
+  }
+}

--- a/packages/backend/src/controllers/goals.controller.ts
+++ b/packages/backend/src/controllers/goals.controller.ts
@@ -32,7 +32,7 @@ export async function listGoalsController(req: Request, res: Response) {
 
     const athleteIdFilter = typeof req.query.athleteId === "string" ? req.query.athleteId : undefined;
 
-    const goals = await listGoals(req.user.userId, moduleId as string, athleteIdFilter);
+    const goals = await listGoals(req.user.userId, req.user.role, moduleId as string, athleteIdFilter);
     return res.status(200).json(goals);
   } catch (error) {
     return handleError(res, error, "List goals");
@@ -60,7 +60,7 @@ export async function updateGoalController(req: Request, res: Response) {
     if (!req.user) return res.status(401).json({ error: "Unauthorized" });
 
     const data = validateUpdateGoal(req.body);
-    const goal = await updateGoal(req.user.userId, req.params.id as string, data);
+    const goal = await updateGoal(req.user.userId, req.user.role, req.params.id as string, data);
 
     return res.status(200).json({ message: "Goal updated successfully", goal });
   } catch (error) {

--- a/packages/backend/src/controllers/routines.controller.ts
+++ b/packages/backend/src/controllers/routines.controller.ts
@@ -37,7 +37,7 @@ export async function listRoutinesController(req: Request, res: Response) {
 
     const athleteIdFilter = typeof req.query.athleteId === "string" ? req.query.athleteId : undefined;
 
-    const routines = await listRoutines(req.user.userId, moduleId as string, athleteIdFilter);
+    const routines = await listRoutines(req.user.userId, req.user.role, moduleId as string, athleteIdFilter);
     return res.status(200).json(routines);
   } catch (error) {
     return handleError(res, error, "List routines");
@@ -48,7 +48,7 @@ export async function getRoutineController(req: Request, res: Response) {
   try {
     if (!req.user) return res.status(401).json({ error: "Unauthorized" });
 
-    const routine = await getRoutine(req.user.userId, req.params.id as string);
+    const routine = await getRoutine(req.user.userId, req.user.role, req.params.id as string);
     return res.status(200).json(routine);
   } catch (error) {
     return handleError(res, error, "Get routine");

--- a/packages/backend/src/controllers/routines.controller.ts
+++ b/packages/backend/src/controllers/routines.controller.ts
@@ -1,0 +1,96 @@
+import { Request, Response } from "express";
+import {
+  listRoutines,
+  getRoutine,
+  createRoutine,
+  updateRoutine,
+  deleteRoutine,
+} from "../services/routines.service";
+import {
+  validateCreateRoutine,
+  validateUpdateRoutine,
+} from "../validators/routines.validator";
+
+function handleError(res: Response, error: unknown, context: string) {
+  const message = error instanceof Error ? error.message : "Internal server error";
+
+  if (message === "Routine not found") return res.status(404).json({ error: message });
+  if (message === "Invalid date format") return res.status(400).json({ error: message });
+  if (
+    message === "Not a member of this module" ||
+    message === "Not authorized" ||
+    message === "Athlete is not a member of this module"
+  ) {
+    return res.status(403).json({ error: message });
+  }
+
+  console.error(`${context} error:`, error);
+  return res.status(500).json({ error: "Internal server error" });
+}
+
+export async function listRoutinesController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const { moduleId } = req.params;
+    if (!moduleId) return res.status(400).json({ error: "Module ID is required" });
+
+    const athleteIdFilter = typeof req.query.athleteId === "string" ? req.query.athleteId : undefined;
+
+    const routines = await listRoutines(req.user.userId, moduleId as string, athleteIdFilter);
+    return res.status(200).json(routines);
+  } catch (error) {
+    return handleError(res, error, "List routines");
+  }
+}
+
+export async function getRoutineController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const routine = await getRoutine(req.user.userId, req.params.id as string);
+    return res.status(200).json(routine);
+  } catch (error) {
+    return handleError(res, error, "Get routine");
+  }
+}
+
+export async function createRoutineController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const { moduleId } = req.params;
+    if (!moduleId) return res.status(400).json({ error: "Module ID is required" });
+
+    const input = validateCreateRoutine(req.body);
+
+    const routine = await createRoutine(req.user.userId, moduleId as string, input);
+    return res.status(201).json({ message: "Routine created successfully", routine });
+  } catch (error) {
+    return handleError(res, error, "Create routine");
+  }
+}
+
+export async function updateRoutineController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    const data = validateUpdateRoutine(req.body);
+    const routine = await updateRoutine(req.user.userId, req.params.id as string, data);
+
+    return res.status(200).json({ message: "Routine updated successfully", routine });
+  } catch (error) {
+    return handleError(res, error, "Update routine");
+  }
+}
+
+export async function deleteRoutineController(req: Request, res: Response) {
+  try {
+    if (!req.user) return res.status(401).json({ error: "Unauthorized" });
+
+    await deleteRoutine(req.user.userId, req.params.id as string);
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    return handleError(res, error, "Delete routine");
+  }
+}

--- a/packages/backend/src/routes/goals.routes.ts
+++ b/packages/backend/src/routes/goals.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/auth.middleware";
+import { requireRole } from "../middleware/role.middleware";
+import {
+  listGoalsController,
+  createGoalController,
+  updateGoalController,
+  deleteGoalController,
+} from "../controllers/goals.controller";
+
+const moduleScoped = Router({ mergeParams: true });
+moduleScoped.get("/", requireAuth, listGoalsController);
+moduleScoped.post("/", requireAuth, requireRole("COACH"), createGoalController);
+
+const byId = Router();
+byId.patch("/:id", requireAuth, updateGoalController);
+byId.delete("/:id", requireAuth, requireRole("COACH"), deleteGoalController);
+
+export { moduleScoped as goalsModuleRouter, byId as goalsByIdRouter };

--- a/packages/backend/src/routes/routines.routes.ts
+++ b/packages/backend/src/routes/routines.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/auth.middleware";
+import { requireRole } from "../middleware/role.middleware";
+import {
+  listRoutinesController,
+  getRoutineController,
+  createRoutineController,
+  updateRoutineController,
+  deleteRoutineController,
+} from "../controllers/routines.controller";
+
+const moduleScoped = Router({ mergeParams: true });
+moduleScoped.get("/", requireAuth, listRoutinesController);
+moduleScoped.post("/", requireAuth, requireRole("COACH"), createRoutineController);
+
+const byId = Router();
+byId.get("/:id", requireAuth, getRoutineController);
+byId.patch("/:id", requireAuth, requireRole("COACH"), updateRoutineController);
+byId.delete("/:id", requireAuth, requireRole("COACH"), deleteRoutineController);
+
+export { moduleScoped as routinesModuleRouter, byId as routinesByIdRouter };

--- a/packages/backend/src/services/goals.service.ts
+++ b/packages/backend/src/services/goals.service.ts
@@ -8,15 +8,16 @@ async function getMembership(userId: string, moduleId: string) {
 
 export async function listGoals(
   userId: string,
+  userRole: string,
   moduleId: string,
   athleteIdFilter?: string
 ) {
   const membership = await getMembership(userId, moduleId);
   if (!membership) throw new Error("Not a member of this module");
 
-  const isCoach = membership.memberRole === "MODULE_ADMIN";
-
-  // Athletes can only see their own goals; coaches can optionally filter by athlete.
+  // Only COACH users get the all-athletes view. Everyone else (ATHLETE,
+  // PARENT) only sees goals assigned to themselves.
+  const isCoach = userRole === "COACH";
   const athleteId = isCoach ? athleteIdFilter : userId;
 
   return prisma.goal.findMany({
@@ -48,6 +49,7 @@ export async function createGoal(
 
 export async function updateGoal(
   userId: string,
+  userRole: string,
   goalId: string,
   data: { title?: string; completed?: boolean }
 ) {
@@ -57,7 +59,7 @@ export async function updateGoal(
   const membership = await getMembership(userId, goal.moduleId);
   if (!membership) throw new Error("Not authorized");
 
-  const isCoach = membership.memberRole === "MODULE_ADMIN";
+  const isCoach = userRole === "COACH";
   const isOwner = goal.athleteId === userId;
 
   // Title edits are coach-only. Completion toggles are allowed for the athlete

--- a/packages/backend/src/services/goals.service.ts
+++ b/packages/backend/src/services/goals.service.ts
@@ -1,0 +1,87 @@
+import prisma from "../lib/prisma";
+
+async function getMembership(userId: string, moduleId: string) {
+  return prisma.moduleMembership.findUnique({
+    where: { userId_moduleId: { userId, moduleId } },
+  });
+}
+
+export async function listGoals(
+  userId: string,
+  moduleId: string,
+  athleteIdFilter?: string
+) {
+  const membership = await getMembership(userId, moduleId);
+  if (!membership) throw new Error("Not a member of this module");
+
+  const isCoach = membership.memberRole === "MODULE_ADMIN";
+
+  // Athletes can only see their own goals; coaches can optionally filter by athlete.
+  const athleteId = isCoach ? athleteIdFilter : userId;
+
+  return prisma.goal.findMany({
+    where: {
+      moduleId,
+      ...(athleteId ? { athleteId } : {}),
+    },
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+export async function createGoal(
+  coachId: string,
+  moduleId: string,
+  athleteId: string,
+  title: string
+) {
+  const membership = await getMembership(coachId, moduleId);
+  if (!membership) throw new Error("Not a member of this module");
+  if (membership.memberRole !== "MODULE_ADMIN") throw new Error("Not authorized");
+
+  const athleteMembership = await getMembership(athleteId, moduleId);
+  if (!athleteMembership) throw new Error("Athlete is not a member of this module");
+
+  return prisma.goal.create({
+    data: { title, moduleId, athleteId, createdById: coachId },
+  });
+}
+
+export async function updateGoal(
+  userId: string,
+  goalId: string,
+  data: { title?: string; completed?: boolean }
+) {
+  const goal = await prisma.goal.findUnique({ where: { id: goalId } });
+  if (!goal) throw new Error("Goal not found");
+
+  const membership = await getMembership(userId, goal.moduleId);
+  if (!membership) throw new Error("Not authorized");
+
+  const isCoach = membership.memberRole === "MODULE_ADMIN";
+  const isOwner = goal.athleteId === userId;
+
+  // Title edits are coach-only. Completion toggles are allowed for the athlete
+  // the goal belongs to, or any coach in the module.
+  if (data.title !== undefined && !isCoach) throw new Error("Not authorized");
+  if (data.completed !== undefined && !isCoach && !isOwner) throw new Error("Not authorized");
+
+  return prisma.goal.update({
+    where: { id: goalId },
+    data: {
+      ...(data.title !== undefined ? { title: data.title } : {}),
+      ...(data.completed !== undefined ? { completed: data.completed } : {}),
+    },
+  });
+}
+
+export async function deleteGoal(userId: string, goalId: string) {
+  const goal = await prisma.goal.findUnique({ where: { id: goalId } });
+  if (!goal) throw new Error("Goal not found");
+
+  const membership = await getMembership(userId, goal.moduleId);
+  if (!membership || membership.memberRole !== "MODULE_ADMIN") {
+    throw new Error("Not authorized");
+  }
+
+  await prisma.goal.delete({ where: { id: goalId } });
+}

--- a/packages/backend/src/services/routines.service.ts
+++ b/packages/backend/src/services/routines.service.ts
@@ -20,13 +20,14 @@ function parseDate(value: string): Date {
 
 export async function listRoutines(
   userId: string,
+  userRole: string,
   moduleId: string,
   athleteIdFilter?: string
 ) {
   const membership = await getMembership(userId, moduleId);
   if (!membership) throw new Error("Not a member of this module");
 
-  const isCoach = membership.memberRole === "MODULE_ADMIN";
+  const isCoach = userRole === "COACH";
   const athleteId = isCoach ? athleteIdFilter : userId;
 
   return prisma.routine.findMany({
@@ -39,7 +40,7 @@ export async function listRoutines(
   });
 }
 
-export async function getRoutine(userId: string, routineId: string) {
+export async function getRoutine(userId: string, userRole: string, routineId: string) {
   const routine = await prisma.routine.findUnique({
     where: { id: routineId },
     include: { deductions: true },
@@ -49,7 +50,7 @@ export async function getRoutine(userId: string, routineId: string) {
   const membership = await getMembership(userId, routine.moduleId);
   if (!membership) throw new Error("Not authorized");
 
-  const isCoach = membership.memberRole === "MODULE_ADMIN";
+  const isCoach = userRole === "COACH";
   const isOwner = routine.athleteId === userId;
   if (!isCoach && !isOwner) throw new Error("Not authorized");
 

--- a/packages/backend/src/services/routines.service.ts
+++ b/packages/backend/src/services/routines.service.ts
@@ -1,0 +1,149 @@
+import prisma from "../lib/prisma";
+
+type DeductionInput = {
+  category: string;
+  value: number;
+  notes?: string;
+};
+
+async function getMembership(userId: string, moduleId: string) {
+  return prisma.moduleMembership.findUnique({
+    where: { userId_moduleId: { userId, moduleId } },
+  });
+}
+
+function parseDate(value: string): Date {
+  const parsed = new Date(value);
+  if (isNaN(parsed.getTime())) throw new Error("Invalid date format");
+  return parsed;
+}
+
+export async function listRoutines(
+  userId: string,
+  moduleId: string,
+  athleteIdFilter?: string
+) {
+  const membership = await getMembership(userId, moduleId);
+  if (!membership) throw new Error("Not a member of this module");
+
+  const isCoach = membership.memberRole === "MODULE_ADMIN";
+  const athleteId = isCoach ? athleteIdFilter : userId;
+
+  return prisma.routine.findMany({
+    where: {
+      moduleId,
+      ...(athleteId ? { athleteId } : {}),
+    },
+    orderBy: { date: "desc" },
+    include: { deductions: true },
+  });
+}
+
+export async function getRoutine(userId: string, routineId: string) {
+  const routine = await prisma.routine.findUnique({
+    where: { id: routineId },
+    include: { deductions: true },
+  });
+  if (!routine) throw new Error("Routine not found");
+
+  const membership = await getMembership(userId, routine.moduleId);
+  if (!membership) throw new Error("Not authorized");
+
+  const isCoach = membership.memberRole === "MODULE_ADMIN";
+  const isOwner = routine.athleteId === userId;
+  if (!isCoach && !isOwner) throw new Error("Not authorized");
+
+  return routine;
+}
+
+export async function createRoutine(
+  coachId: string,
+  moduleId: string,
+  input: {
+    title: string;
+    date: string;
+    athleteId: string;
+    notes?: string;
+    deductions?: DeductionInput[];
+  }
+) {
+  const membership = await getMembership(coachId, moduleId);
+  if (!membership) throw new Error("Not a member of this module");
+  if (membership.memberRole !== "MODULE_ADMIN") throw new Error("Not authorized");
+
+  const athleteMembership = await getMembership(input.athleteId, moduleId);
+  if (!athleteMembership) throw new Error("Athlete is not a member of this module");
+
+  const date = parseDate(input.date);
+
+  return prisma.routine.create({
+    data: {
+      title: input.title,
+      date,
+      notes: input.notes,
+      moduleId,
+      athleteId: input.athleteId,
+      createdById: coachId,
+      deductions: input.deductions && input.deductions.length > 0
+        ? { create: input.deductions }
+        : undefined,
+    },
+    include: { deductions: true },
+  });
+}
+
+export async function updateRoutine(
+  userId: string,
+  routineId: string,
+  data: {
+    title?: string;
+    date?: string;
+    notes?: string | null;
+    deductions?: DeductionInput[];
+  }
+) {
+  const routine = await prisma.routine.findUnique({ where: { id: routineId } });
+  if (!routine) throw new Error("Routine not found");
+
+  const membership = await getMembership(userId, routine.moduleId);
+  if (!membership || membership.memberRole !== "MODULE_ADMIN") {
+    throw new Error("Not authorized");
+  }
+
+  return prisma.$transaction(async tx => {
+    const updated = await tx.routine.update({
+      where: { id: routineId },
+      data: {
+        ...(data.title !== undefined ? { title: data.title } : {}),
+        ...(data.date !== undefined ? { date: parseDate(data.date) } : {}),
+        ...(data.notes !== undefined ? { notes: data.notes } : {}),
+      },
+    });
+
+    if (data.deductions !== undefined) {
+      await tx.deduction.deleteMany({ where: { routineId } });
+      if (data.deductions.length > 0) {
+        await tx.deduction.createMany({
+          data: data.deductions.map(d => ({ ...d, routineId })),
+        });
+      }
+    }
+
+    return tx.routine.findUnique({
+      where: { id: routineId },
+      include: { deductions: true },
+    });
+  });
+}
+
+export async function deleteRoutine(userId: string, routineId: string) {
+  const routine = await prisma.routine.findUnique({ where: { id: routineId } });
+  if (!routine) throw new Error("Routine not found");
+
+  const membership = await getMembership(userId, routine.moduleId);
+  if (!membership || membership.memberRole !== "MODULE_ADMIN") {
+    throw new Error("Not authorized");
+  }
+
+  await prisma.routine.delete({ where: { id: routineId } });
+}

--- a/packages/backend/src/validators/goals.validator.ts
+++ b/packages/backend/src/validators/goals.validator.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+const createGoalSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  athleteId: z.string().min(1, "Athlete ID is required"),
+});
+
+const updateGoalSchema = z
+  .object({
+    title: z.string().min(1, "Title cannot be empty").optional(),
+    completed: z.boolean().optional(),
+  })
+  .refine(data => data.title !== undefined || data.completed !== undefined, {
+    message: "At least one field must be provided",
+  });
+
+export function validateCreateGoal(data: unknown) {
+  const result = createGoalSchema.safeParse(data);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "Validation error";
+    throw new Error(message);
+  }
+  return result.data;
+}
+
+export function validateUpdateGoal(data: unknown) {
+  const result = updateGoalSchema.safeParse(data);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "Validation error";
+    throw new Error(message);
+  }
+  return result.data;
+}

--- a/packages/backend/src/validators/routines.validator.ts
+++ b/packages/backend/src/validators/routines.validator.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+const deductionInputSchema = z.object({
+  category: z.string().min(1, "Deduction category is required"),
+  value: z.number().finite("Deduction value must be a number"),
+  notes: z.string().optional(),
+});
+
+const createRoutineSchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  date: z.string().min(1, "Date is required"),
+  athleteId: z.string().min(1, "Athlete ID is required"),
+  notes: z.string().optional(),
+  deductions: z.array(deductionInputSchema).optional(),
+});
+
+const updateRoutineSchema = z
+  .object({
+    title: z.string().min(1, "Title cannot be empty").optional(),
+    date: z.string().min(1, "Date cannot be empty").optional(),
+    notes: z.string().nullable().optional(),
+    deductions: z.array(deductionInputSchema).optional(),
+  })
+  .refine(
+    data =>
+      data.title !== undefined ||
+      data.date !== undefined ||
+      data.notes !== undefined ||
+      data.deductions !== undefined,
+    { message: "At least one field must be provided" }
+  );
+
+export function validateCreateRoutine(data: unknown) {
+  const result = createRoutineSchema.safeParse(data);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "Validation error";
+    throw new Error(message);
+  }
+  return result.data;
+}
+
+export function validateUpdateRoutine(data: unknown) {
+  const result = updateRoutineSchema.safeParse(data);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "Validation error";
+    throw new Error(message);
+  }
+  return result.data;
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import ModuleAttendanceScreen from './pages/ModuleAttendanceScreen'
 import Messaging from './pages/Inbox'
 import ConversationDetail from './pages/ConversationDetail'
 import NewMessage from './pages/NewMessage'
+import ProgressScreen from './pages/ProgressScreen'
 import ProgressPage from './pages/ProgressPage'
 
 function CalendarRoute() {
@@ -61,7 +62,8 @@ export default function App() {
         <Route path="/modules/:id/messaging" element={<Messaging />} />
         <Route path="/modules/:id/messages/:conversationId" element={<ConversationDetail />} />
         <Route path="/modules/:id/messages/new" element={<NewMessage />} />
-        <Route path="/modules/:moduleId/progress" element={<ProgressPage />} />
+        <Route path="/modules/:moduleId/progress" element={<ProgressScreen />} />
+        <Route path="/modules/:moduleId/progress/scores" element={<ProgressPage />} />
 
 
       </Routes>

--- a/packages/frontend/src/pages/ProgressScreen.tsx
+++ b/packages/frontend/src/pages/ProgressScreen.tsx
@@ -1,19 +1,31 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useNavigate, useParams } from 'react-router-dom'
 import BottomNav from '../components/BottomNav'
 import { useAuth } from '../context/AuthContext'
+import { api } from '../utils/api'
 
 type Goal = {
-  id: number
+  id: string
   title: string
   completed: boolean
+  athleteId: string
+}
+
+type Deduction = {
+  id?: string
+  category: string
+  value: number
+  notes?: string | null
 }
 
 type Routine = {
-  id: number
+  id: string
   title: string
-  notes: string
+  date: string
+  notes: string | null
+  athleteId: string
+  deductions: Deduction[]
 }
 
 const fontFamily = '"Amiko", sans-serif'
@@ -29,12 +41,14 @@ const hoverTransition = { type: 'spring' as const, stiffness: 320, damping: 22 }
 
 const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 
-const initialGoals: Goal[] = [
-  { id: 1, title: 'Hit 0', completed: false },
-  { id: 2, title: 'Upgrade elites', completed: true },
-  { id: 3, title: 'Get a paid bid', completed: false },
-  { id: 4, title: 'Add in punch fronts', completed: true },
-]
+function parseUserId(token: string): string {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    return payload.userId ?? ''
+  } catch {
+    return ''
+  }
+}
 
 function ymd(date: Date) {
   const y = date.getFullYear()
@@ -193,7 +207,7 @@ function GoalRow({
   onToggle,
 }: {
   goal: Goal
-  onToggle: (id: number) => void
+  onToggle: (id: string) => void
 }) {
   return (
     <motion.button
@@ -561,11 +575,12 @@ export default function ProgressScreen() {
   const navigate = useNavigate()
   const { id, moduleId } = useParams<{ id: string; moduleId: string }>()
   const currentModuleId = id ?? moduleId
-  const { role } = useAuth()
+  const { role, token } = useAuth()
 
   const [activeTab, setActiveTab] = useState<'goals' | 'routines'>('goals')
 
-  const [goals, setGoals] = useState<Goal[]>(initialGoals)
+  const [goals, setGoals] = useState<Goal[]>([])
+  const [goalsLoading, setGoalsLoading] = useState(true)
   const [showAddGoal, setShowAddGoal] = useState(false)
   const [goalInput, setGoalInput] = useState('')
 
@@ -573,32 +588,51 @@ export default function ProgressScreen() {
 
   const [selectedRoutineDate, setSelectedRoutineDate] = useState(defaultRoutineDate)
   const [calendarOpen, setCalendarOpen] = useState(false)
-  const [routinesByDate, setRoutinesByDate] = useState<Record<string, Routine[]>>({
-    [defaultRoutineDate]: [
-      {
-        id: 1,
-        title: 'Full Out 1',
-        notes: 'Run full routine with counts and clean ending.',
-      },
-      {
-        id: 2,
-        title: 'Tumbling Run Through 1',
-        notes: 'Focus on timing and pass consistency.',
-      },
-      {
-        id: 3,
-        title: 'Stunt Section 1',
-        notes: 'Review transitions and hit positions.',
-      },
-    ],
-  })
+  const [routines, setRoutines] = useState<Routine[]>([])
+  const [routinesLoading, setRoutinesLoading] = useState(true)
 
   const [showRoutineModal, setShowRoutineModal] = useState(false)
-  const [editingRoutineId, setEditingRoutineId] = useState<number | null>(null)
+  const [editingRoutineId, setEditingRoutineId] = useState<string | null>(null)
   const [routineTitle, setRoutineTitle] = useState('')
   const [routineNotes, setRoutineNotes] = useState('')
+  const [routineDeductions, setRoutineDeductions] = useState<Deduction[]>([])
+  const [savingRoutine, setSavingRoutine] = useState(false)
 
   const canManageRoutines = role === 'COACH'
+
+  useEffect(() => {
+    if (!currentModuleId || !token) return
+
+    let cancelled = false
+
+    setGoalsLoading(true)
+    api<Goal[]>(`/modules/${currentModuleId}/goals`, { token })
+      .then(data => {
+        if (!cancelled) setGoals(data)
+      })
+      .catch(error => {
+        if (!cancelled) console.error('Failed to load goals', error)
+      })
+      .finally(() => {
+        if (!cancelled) setGoalsLoading(false)
+      })
+
+    setRoutinesLoading(true)
+    api<Routine[]>(`/modules/${currentModuleId}/routines`, { token })
+      .then(data => {
+        if (!cancelled) setRoutines(data)
+      })
+      .catch(error => {
+        if (!cancelled) console.error('Failed to load routines', error)
+      })
+      .finally(() => {
+        if (!cancelled) setRoutinesLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [currentModuleId, token])
 
   const completedCount = useMemo(
     () => goals.filter(goal => goal.completed).length,
@@ -610,44 +644,70 @@ export default function ProgressScreen() {
     return Math.round((completedCount / goals.length) * 100)
   }, [completedCount, goals])
 
-  const routinesForSelectedDate = routinesByDate[selectedRoutineDate] ?? []
+  const routinesForSelectedDate = useMemo(
+    () => routines.filter(r => r.date.slice(0, 10) === selectedRoutineDate),
+    [routines, selectedRoutineDate]
+  )
 
-  const toggleGoal = (goalId: number) => {
+  const toggleGoal = async (goalId: string) => {
+    if (!token) return
+    const previous = goals
+    const target = previous.find(g => g.id === goalId)
+    if (!target) return
+
+    const nextCompleted = !target.completed
     setGoals(prev =>
       prev.map(goal =>
-        goal.id === goalId ? { ...goal, completed: !goal.completed } : goal
+        goal.id === goalId ? { ...goal, completed: nextCompleted } : goal
       )
     )
+
+    try {
+      await api<{ goal: Goal }>(`/goals/${goalId}`, {
+        method: 'PATCH',
+        body: { completed: nextCompleted },
+        token,
+      })
+    } catch (error) {
+      console.error('Failed to update goal', error)
+      setGoals(previous)
+    }
   }
 
-  const addGoal = () => {
+  const addGoal = async () => {
     const title = goalInput.trim()
-    if (!title) return
+    if (!title || !currentModuleId || !token) return
 
-    setGoals(prev => [
-      ...prev,
-      {
-        id: Date.now(),
-        title,
-        completed: false,
-      },
-    ])
-
-    setGoalInput('')
-    setShowAddGoal(false)
+    try {
+      const res = await api<{ goal: Goal }>(
+        `/modules/${currentModuleId}/goals`,
+        {
+          method: 'POST',
+          body: { title, athleteId: parseUserId(token) },
+          token,
+        }
+      )
+      setGoals(prev => [...prev, res.goal])
+      setGoalInput('')
+      setShowAddGoal(false)
+    } catch (error) {
+      console.error('Failed to add goal', error)
+    }
   }
 
   const openNewRoutine = () => {
     setEditingRoutineId(null)
     setRoutineTitle('')
     setRoutineNotes('')
+    setRoutineDeductions([])
     setShowRoutineModal(true)
   }
 
   const openEditRoutine = (routine: Routine) => {
     setEditingRoutineId(routine.id)
     setRoutineTitle(routine.title)
-    setRoutineNotes(routine.notes)
+    setRoutineNotes(routine.notes ?? '')
+    setRoutineDeductions(routine.deductions.map(d => ({ ...d })))
     setShowRoutineModal(true)
   }
 
@@ -656,52 +716,84 @@ export default function ProgressScreen() {
     setEditingRoutineId(null)
     setRoutineTitle('')
     setRoutineNotes('')
+    setRoutineDeductions([])
   }
 
-  const saveRoutine = () => {
+  const addDeductionRow = () => {
+    setRoutineDeductions(prev => [...prev, { category: '', value: 0, notes: '' }])
+  }
+
+  const updateDeductionRow = (index: number, patch: Partial<Deduction>) => {
+    setRoutineDeductions(prev =>
+      prev.map((row, i) => (i === index ? { ...row, ...patch } : row))
+    )
+  }
+
+  const removeDeductionRow = (index: number) => {
+    setRoutineDeductions(prev => prev.filter((_, i) => i !== index))
+  }
+
+  const saveRoutine = async () => {
     const trimmedTitle = routineTitle.trim()
-    if (!trimmedTitle) return
+    if (!trimmedTitle || !currentModuleId || !token) return
 
-    setRoutinesByDate(prev => {
-      const current = prev[selectedRoutineDate] ?? []
+    const cleanedDeductions = routineDeductions
+      .map(d => ({
+        category: d.category.trim(),
+        value: Number(d.value) || 0,
+        notes: d.notes?.toString().trim() || undefined,
+      }))
+      .filter(d => d.category.length > 0)
 
+    setSavingRoutine(true)
+    try {
       if (editingRoutineId !== null) {
-        return {
-          ...prev,
-          [selectedRoutineDate]: current.map(routine =>
-            routine.id === editingRoutineId
-              ? {
-                  ...routine,
-                  title: trimmedTitle,
-                  notes: routineNotes.trim(),
-                }
-              : routine
-          ),
-        }
+        const res = await api<{ routine: Routine }>(`/routines/${editingRoutineId}`, {
+          method: 'PATCH',
+          body: {
+            title: trimmedTitle,
+            notes: routineNotes.trim() || null,
+            deductions: cleanedDeductions,
+          },
+          token,
+        })
+        setRoutines(prev => prev.map(r => (r.id === res.routine.id ? res.routine : r)))
+      } else {
+        const res = await api<{ routine: Routine }>(
+          `/modules/${currentModuleId}/routines`,
+          {
+            method: 'POST',
+            body: {
+              title: trimmedTitle,
+              date: selectedRoutineDate,
+              athleteId: parseUserId(token),
+              notes: routineNotes.trim() || undefined,
+              deductions: cleanedDeductions,
+            },
+            token,
+          }
+        )
+        setRoutines(prev => [res.routine, ...prev])
       }
-
-      const newRoutine: Routine = {
-        id: Date.now(),
-        title: trimmedTitle,
-        notes: routineNotes.trim(),
-      }
-
-      return {
-        ...prev,
-        [selectedRoutineDate]: [...current, newRoutine],
-      }
-    })
-
-    closeRoutineModal()
+      closeRoutineModal()
+    } catch (error) {
+      console.error('Failed to save routine', error)
+    } finally {
+      setSavingRoutine(false)
+    }
   }
 
-  const deleteRoutine = (routineId: number) => {
-    setRoutinesByDate(prev => ({
-      ...prev,
-      [selectedRoutineDate]: (prev[selectedRoutineDate] ?? []).filter(
-        routine => routine.id !== routineId
-      ),
-    }))
+  const deleteRoutine = async (routineId: string) => {
+    if (!token) return
+    const previous = routines
+    setRoutines(prev => prev.filter(r => r.id !== routineId))
+
+    try {
+      await api(`/routines/${routineId}`, { method: 'DELETE', token })
+    } catch (error) {
+      console.error('Failed to delete routine', error)
+      setRoutines(previous)
+    }
   }
 
   return (
@@ -1000,11 +1092,29 @@ export default function ProgressScreen() {
                     gap: '10px',
                   }}
                 >
-                  {goals.map(goal => (
-                    <GoalRow key={goal.id} goal={goal} onToggle={toggleGoal} />
-                  ))}
+                  {goals.length > 0 ? (
+                    goals.map(goal => (
+                      <GoalRow key={goal.id} goal={goal} onToggle={toggleGoal} />
+                    ))
+                  ) : (
+                    <div
+                      style={{
+                        borderRadius: '16px',
+                        border: '1px dashed #D9DEEB',
+                        background: '#FCFCFF',
+                        padding: '20px 14px',
+                        textAlign: 'center',
+                        fontFamily,
+                        fontSize: '13px',
+                        color: textSecondary,
+                      }}
+                    >
+                      {goalsLoading ? 'Loading goals…' : 'No goals assigned yet.'}
+                    </div>
+                  )}
                 </div>
 
+                {canManageRoutines ? (
                 <div style={{ marginTop: '16px' }}>
                   <AnimatePresence mode="wait">
                     {!showAddGoal ? (
@@ -1161,6 +1271,7 @@ export default function ProgressScreen() {
                     )}
                   </AnimatePresence>
                 </div>
+                ) : null}
               </motion.div>
             </>
           ) : (
@@ -1336,7 +1447,7 @@ export default function ProgressScreen() {
                         marginBottom: '6px',
                       }}
                     >
-                      No routines for this date yet
+                      {routinesLoading ? 'Loading routines…' : 'No routines for this date yet'}
                     </div>
 
                     <div
@@ -1527,6 +1638,134 @@ export default function ProgressScreen() {
                   />
                 </div>
 
+                <div style={{ marginBottom: '18px' }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '8px',
+                    }}
+                  >
+                    <label
+                      style={{
+                        fontFamily,
+                        fontSize: '12px',
+                        fontWeight: 700,
+                        color: textSecondary,
+                      }}
+                    >
+                      Deductions
+                    </label>
+                    <button
+                      type="button"
+                      onClick={addDeductionRow}
+                      style={{
+                        height: '28px',
+                        padding: '0 12px',
+                        borderRadius: '999px',
+                        border: '1px solid #DFE5F0',
+                        background: '#FFFFFF',
+                        fontFamily,
+                        fontSize: '12px',
+                        fontWeight: 700,
+                        color: accent,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      + Add
+                    </button>
+                  </div>
+
+                  {routineDeductions.length === 0 ? (
+                    <div
+                      style={{
+                        borderRadius: '12px',
+                        border: '1px dashed #DFE5F0',
+                        padding: '10px 12px',
+                        fontFamily,
+                        fontSize: '12px',
+                        color: textSecondary,
+                      }}
+                    >
+                      No deductions recorded yet.
+                    </div>
+                  ) : (
+                    <div style={{ display: 'grid', gap: '8px' }}>
+                      {routineDeductions.map((row, i) => (
+                        <div
+                          key={row.id ?? `new-${i}`}
+                          style={{
+                            display: 'grid',
+                            gridTemplateColumns: '1fr 72px 28px',
+                            gap: '8px',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <input
+                            value={row.category}
+                            onChange={e =>
+                              updateDeductionRow(i, { category: e.target.value })
+                            }
+                            placeholder="Category (e.g. Tumbling)"
+                            style={{
+                              height: '38px',
+                              borderRadius: '10px',
+                              border: '1px solid #DFE5F0',
+                              padding: '0 10px',
+                              fontFamily,
+                              fontSize: '13px',
+                              color: textPrimary,
+                              background: '#FBFCFF',
+                              outline: 'none',
+                              boxSizing: 'border-box',
+                            }}
+                          />
+                          <input
+                            type="number"
+                            step="0.05"
+                            value={row.value}
+                            onChange={e =>
+                              updateDeductionRow(i, { value: Number(e.target.value) })
+                            }
+                            placeholder="0.0"
+                            style={{
+                              height: '38px',
+                              borderRadius: '10px',
+                              border: '1px solid #DFE5F0',
+                              padding: '0 10px',
+                              fontFamily,
+                              fontSize: '13px',
+                              color: textPrimary,
+                              background: '#FBFCFF',
+                              outline: 'none',
+                              boxSizing: 'border-box',
+                            }}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removeDeductionRow(i)}
+                            style={{
+                              width: '28px',
+                              height: '28px',
+                              borderRadius: '50%',
+                              border: 'none',
+                              background: '#D94C4C',
+                              color: '#FFFFFF',
+                              fontSize: '14px',
+                              fontWeight: 700,
+                              cursor: 'pointer',
+                              lineHeight: 1,
+                            }}
+                          >
+                            ×
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
                 <div
                   style={{
                     display: 'flex',
@@ -1554,6 +1793,7 @@ export default function ProgressScreen() {
 
                   <button
                     onClick={saveRoutine}
+                    disabled={savingRoutine}
                     style={{
                       height: '42px',
                       padding: '0 18px',
@@ -1564,11 +1804,16 @@ export default function ProgressScreen() {
                       fontSize: '13px',
                       fontWeight: 700,
                       color: '#FFFFFF',
-                      cursor: 'pointer',
+                      cursor: savingRoutine ? 'not-allowed' : 'pointer',
+                      opacity: savingRoutine ? 0.7 : 1,
                       boxShadow: '0 10px 20px rgba(98, 103, 227, 0.24)',
                     }}
                   >
-                    {editingRoutineId !== null ? 'Save Changes' : 'Add Routine'}
+                    {savingRoutine
+                      ? 'Saving…'
+                      : editingRoutineId !== null
+                        ? 'Save Changes'
+                        : 'Add Routine'}
                   </button>
                 </div>
               </motion.div>


### PR DESCRIPTION
## Summary

Implements Russell's Sprint 3 tickets for the Progress module (GP-71, 72, 101, 102, 105, 106 — plus GP-107 read-path). Covers the write-path and data layer; Marissa owns the remaining analytics views (GP-73, 108) and the individual routine detail (GP-107 frontend).

### Backend
- New Prisma models: \`Goal\`, \`Routine\`, \`Deduction\` + reverse relations on \`User\` / \`Module\`
- Migration: \`20260420034154_add_goals_routines_deductions\`
- Services + controllers + zod validators matching the events/announcements pattern (\`requireAuth\` + \`requireRole(\"COACH\")\` at the route, \`MODULE_ADMIN\` membership check in the service)
- Role-based read filter: \`req.user.role === \"COACH\"\` → module-wide view (optional \`?athleteId=\` filter); otherwise own-goals / own-routines only

### Endpoints
- \`GET  /api/modules/:moduleId/goals\`, \`POST /api/modules/:moduleId/goals\`
- \`PATCH /api/goals/:id\` (title is coach-only, completed toggle is athlete-or-coach)
- \`DELETE /api/goals/:id\` (coach only)
- \`GET  /api/modules/:moduleId/routines\`, \`POST /api/modules/:moduleId/routines\`
- \`GET /api/routines/:id\`, \`PATCH /api/routines/:id\`, \`DELETE /api/routines/:id\` (coach only for write)
- Routine POST/PATCH accepts a \`deductions: { category, value, notes? }[]\` array (GP-106)

### Frontend (ProgressScreen.tsx)
- Keeps Lex's UI intact — swaps in-memory state for \`api()\` calls
- Goals tab: loads + persists add/toggle, empty-state message when none assigned, Add Goal button hidden from non-coaches
- Routines tab: loads + persists add/edit/delete, new deduction editor (category + numeric value + remove) inside the modal
- Optimistic UI with rollback on error for goal toggle and routine delete

## Known gaps / out of scope
- No parent → athlete association in the schema yet; parent role falls back to own-view (tracked separately)
- Coach adding goals/routines from their own ProgressScreen assigns them to the coach — proper athlete picker lives with Marissa's GP-107 detail view

## Test plan
- [x] Build both packages + backend typecheck clean
- [x] Manually tested as coach + athlete on the Team module (goals persist, completion ring updates, routine with deductions saves, role filter verified via curl)
- [ ] Reviewer: confirm CI builds both packages (backend CI will trigger since \`packages/backend/**\` changed)