### PR TITLE
Feat/pubsub realtime messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,18 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "^9.0.3",
+    "redis": "^5.12.1",
+    "socket.io": "^4.8.3"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
     "@types/jsonwebtoken": "^9.0.10"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["bcrypt", "@prisma/engines"]
+    "onlyBuiltDependencies": [
+      "bcrypt",
+      "@prisma/engines"
+    ]
   }
 }

--- a/packages/backend/src/lib/redis.ts
+++ b/packages/backend/src/lib/redis.ts
@@ -1,0 +1,32 @@
+import { createClient } from "redis";
+const redisUrl = process.env.REDIS_URL;
+
+if (!redisUrl) {
+    throw new Error("Missing REDIS_URL");
+}
+
+export const publisher = createClient({
+    url: redisUrl,
+});
+
+export const subscriber = publisher.duplicate();
+
+publisher.on("error", (err) => {
+    console.error("Redis Publisher Error:", err)
+});
+
+subscriber.on("error", (err) => {
+    console.error("Redis Subscriber Error:", err);
+});
+
+export async function connectRedis() {
+    if (!publisher.isOpen) {
+        await publisher.connect();
+    }
+
+    if (!subscriber.isOpen) {
+        await subscriber.connect();
+    }
+
+    console.log("Redis connected");
+}

--- a/packages/backend/src/lib/socket.ts
+++ b/packages/backend/src/lib/socket.ts
@@ -1,0 +1,25 @@
+import { Server } from "socket.io";
+
+let io: Server;
+
+export function initializeSocket(server: any) {
+    io = new Server(server, {
+        cors: {
+            origin: "*",
+        },
+    });
+
+    io.on("connection", (socket) => {
+        console.log(`Socket connected: ${socket.id}`);
+    });
+
+    return io;
+}
+
+export function getIO() {
+    if (!io) {
+        throw new Error("Socket.IO not initialized");
+    }
+
+    return io;
+}

--- a/packages/backend/src/lib/socket.ts
+++ b/packages/backend/src/lib/socket.ts
@@ -11,6 +11,20 @@ export function initializeSocket(server: any) {
 
     io.on("connection", (socket) => {
         console.log(`Socket connected: ${socket.id}`);
+
+        socket.on("conversation.join", (conversationId: string) => {
+            socket.join(`conversation:${conversationId}`);
+            console.log(`Socket ${socket.id} joined conversation: ${conversationId}`);
+        });
+
+        socket.on("conversation.leave", (conversationId: string) => {
+            socket.leave(`conversation:${conversationId}`);
+            console.log(`Socket ${socket.id} left conversation: ${conversationId}`);
+        });
+
+        socket.on("disconnect", () => {
+            console.log(`Socket disconnect: ${socket.id}`);
+        });
     });
 
     return io;

--- a/packages/backend/src/lib/socket.ts
+++ b/packages/backend/src/lib/socket.ts
@@ -14,12 +14,10 @@ export function initializeSocket(server: any) {
 
         socket.on("conversation.join", (conversationId: string) => {
             socket.join(`conversation:${conversationId}`);
-            console.log(`Socket ${socket.id} joined conversation: ${conversationId}`);
         });
 
         socket.on("conversation.leave", (conversationId: string) => {
             socket.leave(`conversation:${conversationId}`);
-            console.log(`Socket ${socket.id} left conversation: ${conversationId}`);
         });
 
         socket.on("disconnect", () => {

--- a/packages/backend/src/pubsub/messaging.subscriber.ts
+++ b/packages/backend/src/pubsub/messaging.subscriber.ts
@@ -11,6 +11,16 @@ export async function subscribeToMessagingEvents() {
     await subscriber.subscribe("messaging", (message) => {
         try {
             const event = JSON.parse(message) as PubSubEvent;
+
+            console.log(
+
+                "Pub/Sub event received:",
+
+                event.type,
+
+                event.conversationId
+
+            );
             const io = getIO();
             io.to(`conversation:${event.conversationId}`).emit(event.type, event.payload);
         } catch (error) {

--- a/packages/backend/src/pubsub/messaging.subscriber.ts
+++ b/packages/backend/src/pubsub/messaging.subscriber.ts
@@ -11,16 +11,6 @@ export async function subscribeToMessagingEvents() {
     await subscriber.subscribe("messaging", (message) => {
         try {
             const event = JSON.parse(message) as PubSubEvent;
-
-            console.log(
-
-                "Pub/Sub event received:",
-
-                event.type,
-
-                event.conversationId
-
-            );
             const io = getIO();
             io.to(`conversation:${event.conversationId}`).emit(event.type, event.payload);
         } catch (error) {

--- a/packages/backend/src/pubsub/messaging.subscriber.ts
+++ b/packages/backend/src/pubsub/messaging.subscriber.ts
@@ -1,0 +1,22 @@
+import { subscriber } from "../lib/redis";
+import { getIO } from "../lib/socket";
+
+type PubSubEvent = {
+    type: string;
+    conversationId: string;
+    payload: unknown;
+};
+
+export async function subscribeToMessagingEvents() {
+    await subscriber.subscribe("messaging", (message) => {
+        try {
+            const event = JSON.parse(message) as PubSubEvent;
+            const io = getIO();
+            io.to(`conversation:${event.conversationId}`).emit(event.type, event.payload);
+        } catch (error) {
+            console.error("failed to handle messaging pub/sub event:", error);
+        }
+    });
+
+    console.log("Subscribed to messaging pub/sub events");
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -1,14 +1,19 @@
 import app from "./app";
+import http from "http";
 import { config } from "./config/env";
 import { connectRedis } from "./lib/redis";
+import { initializeSocket } from "./lib/socket";
+
 
 const PORT = config.port || 3000;
 
 async function startServer() {
   try {
     await connectRedis();
+    const server = http.createServer(app);
+    initializeSocket(server);
 
-    app.listen(PORT, () => {
+    server.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });
   } catch (error) {

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -3,6 +3,7 @@ import http from "http";
 import { config } from "./config/env";
 import { connectRedis } from "./lib/redis";
 import { initializeSocket } from "./lib/socket";
+import { subscribeToMessagingEvents } from "./pubsub/messaging.subscriber";
 
 
 const PORT = config.port || 3000;
@@ -12,6 +13,7 @@ async function startServer() {
     await connectRedis();
     const server = http.createServer(app);
     initializeSocket(server);
+    await subscribeToMessagingEvents();
 
     server.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -1,8 +1,20 @@
 import app from "./app";
 import { config } from "./config/env";
+import { connectRedis } from "./lib/redis";
 
 const PORT = config.port || 3000;
 
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+async function startServer() {
+  try {
+    await connectRedis();
+
+    app.listen(PORT, () => {
+      console.log(`Server running on port ${PORT}`);
+    });
+  } catch (error) {
+    console.error("Startup failed:", error);
+    process.exit(1);
+  }
+}
+
+startServer();

--- a/packages/backend/src/services/conversation.service.ts
+++ b/packages/backend/src/services/conversation.service.ts
@@ -1,4 +1,5 @@
 import prisma from "../lib/prisma";
+import { publisher } from "../lib/redis";
 
 export async function createGroupConversation(moduleId: string, name: string, memberIds: string[]) {
     return prisma.conversation.create({
@@ -124,12 +125,7 @@ export async function getMessages(conversationId: string, userId: string) {
     }));
 }
 
-export async function sendMessage
-    (
-        conversationId: string,
-        senderId: string,
-        content: string) {
-
+export async function sendMessage(conversationId: string, senderId: string, content: string) {
     const membership = await prisma.conversationMember.findFirst({
         where: {
             conversationId,
@@ -146,6 +142,18 @@ export async function sendMessage
             conversationId,
             senderId,
             content,
+        },
+        include: {
+            sender: {
+                select: {
+                    id: true,
+                    username: true,
+                    firstName: true,
+                    lastName: true,
+                    role: true,
+                    profilePicture: true,
+                }
+            }
         }
     });
 
@@ -158,6 +166,31 @@ export async function sendMessage
         },
     });
 
+    await publisher.publish(
+        "messaging",
+        JSON.stringify({
+            type: "message.created",
+            conversationId,
+            payload: {
+                conversationId,
+                message,
+            },
+        })
+    );
+
+    await publisher.publish(
+        "messaging",
+        JSON.stringify({
+            type: "conversation.updated",
+            conversationId,
+            payload: {
+                conversationId,
+                latestMessage: message.content,
+                latestMessageTime: message.createdAt,
+                senderId,
+            },
+        })
+    );
     return message;
 }
 
@@ -194,13 +227,32 @@ export async function markMessageAsRead(conversationId: string, userId: string) 
         return { count: 0 };
     }
 
+    const readAt = new Date();
+
     await prisma.messageRead.createMany({
         data: unreadMessages.map((message) => ({
             messageId: message.id,
             userId,
+            readAt,
         })),
         skipDuplicates: true,
     });
+
+    const messageIds = unreadMessages.map((message) => message.id);
+
+    await publisher.publish(
+        "messaging",
+        JSON.stringify({
+            type: "message.read",
+            conversationId,
+            payload: {
+                conversationId,
+                userId,
+                messageIds,
+                readAt,
+            },
+        })
+    );
 
     return { count: unreadMessages.length };
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^19.2.0",
     "react-router": "^7.13.2",
     "react-router-dom": "^7.13.1",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/packages/frontend/src/context/AuthContext.tsx
+++ b/packages/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
+import { disconnectSocket } from "../utils/socket";
 
 interface AuthState {
   token: string | null;
@@ -44,6 +45,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setRole(parseRole(newToken));
   };
   const logout = () => {
+    disconnectSocket();
     setToken(null);
     setRole(null);
   };

--- a/packages/frontend/src/pages/ConversationDetail.tsx
+++ b/packages/frontend/src/pages/ConversationDetail.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../utils/api';
 import BottomNav from '../components/BottomNav'
+import { getSocket } from '../utils/socket';
 
 interface Message {
   id: string
@@ -12,6 +13,7 @@ interface Message {
   content: string
   isRead: boolean
   createdAt: string
+  readAt?: string | null
   sender: {
     id: string
     username: string
@@ -66,16 +68,67 @@ export default function ConversationDetail() {
       .finally(() => setLoading(false))
   }, [token, conversationId])
 
-  // Poll for new messages every 3 seconds
-  useEffect(() => {
-    if (!token || !conversationId) return
-    const interval = setInterval(() => {
-      api<{ messages: Message[] }>(`/conversations/${conversationId}/messages`, { token })
-        .then(data => setMessages(data.messages))
-        .catch(() => {})
-    }, 3000)
-    return () => clearInterval(interval)
-  }, [token, conversationId])
+// Connect to socket room & listen for live messages and read updates
+useEffect(() => {
+  if (!token || !conversationId || !currentUserId) return;
+
+  const socket = getSocket(token);
+
+  const joinRoom = () => {
+    socket.emit("conversation.join", conversationId);
+  };
+
+  if (socket.connected) {
+    joinRoom();
+  } else {
+    socket.on("connect", joinRoom);
+  }
+
+  socket.on("connect_error", (err) => {
+    console.error("Socket connection error:", err.message);
+  });
+
+  const handleMessageCreated = (payload: {
+    conversationId: string;
+    message: Message;
+  }) => {
+    if (payload.conversationId !== conversationId) return;
+
+    setMessages((prev) => {
+      const alreadyExists = prev.some((msg) => msg.id === payload.message.id);
+      if (alreadyExists) return prev;
+      return [...prev, payload.message];
+    });
+  };
+
+  const handleMessageRead = (payload: {
+    conversationId: string;
+    userId: string;
+    messageIds: string[];
+    readAt: string;
+  }) => {
+    if (payload.conversationId !== conversationId) return;
+
+    setMessages((prev) =>
+      prev.map((msg) =>
+        payload.messageIds.includes(msg.id)
+          ? { ...msg, isRead: true, readAt: payload.readAt }
+          : msg
+      )
+    );
+  };
+
+  socket.on("message.created", handleMessageCreated);
+  socket.on("message.read", handleMessageRead);
+
+  return () => {
+    socket.emit("conversation.leave", conversationId);
+
+    socket.off("connect", joinRoom);
+    socket.off("message.created", handleMessageCreated);
+    socket.off("message.read", handleMessageRead);
+  };
+}, [token, conversationId, currentUserId]);
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -91,7 +144,7 @@ export default function ConversationDetail() {
         token: token ?? undefined,
         body: { content },
       })
-      setMessages(prev => [...prev, data.data])
+      //setMessages(prev => [...prev, data.data])
       setContent('')
     } catch {
       // handle error silently

--- a/packages/frontend/src/pages/ConversationDetail.tsx
+++ b/packages/frontend/src/pages/ConversationDetail.tsx
@@ -135,23 +135,28 @@ useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  async function handleSend() {
-    if (!content.trim() || sending) return
-    setSending(true)
-    try {
-      const data = await api<{ data: Message }>(`/conversations/${conversationId}/message`, {
-        method: 'POST',
+async function handleSend() {
+  if (!content.trim() || sending) return;
+
+  setSending(true);
+
+  try {
+    await api<{ data: Message }>(
+      `/conversations/${conversationId}/message`,
+      {
+        method: "POST",
         token: token ?? undefined,
         body: { content },
-      })
-      //setMessages(prev => [...prev, data.data])
-      setContent('')
-    } catch {
-      // handle error silently
-    } finally {
-      setSending(false)
-    }
+      }
+    );
+
+    setContent("");
+  } catch {
+    // handle error silently
+  } finally {
+    setSending(false);
   }
+}
 
   const formatTime = (dateStr: string) =>
     new Date(dateStr).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })

--- a/packages/frontend/src/pages/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../utils/api';
 import BottomNav from '../components/BottomNav'
+import { getSocket } from '../utils/socket';
 
 interface Conversation {
   id: string
@@ -15,23 +16,89 @@ interface Conversation {
   hasUnread: boolean
   profilePicture?: string | null
   members: { id: string; firstName: string; lastName: string }[]
+
 }
+
+type ConversationUpdatedPayload = {
+  conversationId: string;
+  latestMessage: string;
+  latestMessageTime: string;
+  senderId: string;
+};
+
+type MessageReadPayload = {
+  conversationId: string;
+  userId: string;
+};
 
 export default function Messaging() {
   const { id: moduleId } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { token } = useAuth()
-
+  
   const [conversations, setConversations] = useState<Conversation[]>([])
+
+  const currentUserId = token
+  ? JSON.parse(atob(token.split('.')[1])).userId
+  : null
 
   useEffect(() => {
     if (!token) return
     api<{ previews: Conversation[] }>(`/conversations?moduleId=${moduleId}`, { token })
       .then(data => {
-        console.log('conversations:', data.previews)
         setConversations(data.previews)})
       .catch(() => {})
   }, [token, moduleId])
+
+  useEffect(() => {
+  if (!token || !currentUserId || conversations.length === 0) return
+
+  const socket = getSocket(token)
+
+  conversations.forEach((conv) => {
+    socket.emit("conversation.join", conv.id)
+  })
+
+  const handleConversationUpdated = (payload: ConversationUpdatedPayload) => {
+    setConversations((prev) =>
+      prev.map((conv) =>
+        conv.id === payload.conversationId
+          ? {
+              ...conv,
+              latestMessage: payload.latestMessage,
+              latestMessageTime: payload.latestMessageTime,
+              hasUnread:
+              payload.senderId !== currentUserId ? true : conv.hasUnread,
+            }
+          : conv
+      )
+    )
+  }
+
+  const handleMessageRead = (payload: MessageReadPayload) => {
+    if (payload.userId !== currentUserId) return
+
+    setConversations((prev) =>
+      prev.map((conv) =>
+        conv.id === payload.conversationId
+          ? { ...conv, hasUnread: false }
+          : conv
+      )
+    )
+  }
+
+  socket.on("conversation.updated", handleConversationUpdated)
+  socket.on("message.read", handleMessageRead)
+
+  return () => {
+    conversations.forEach((conv) => {
+      socket.emit("conversation.leave", conv.id)
+    })
+
+    socket.off("conversation.updated", handleConversationUpdated)
+    socket.off("message.read", handleMessageRead)
+  }
+}, [token, currentUserId, conversations])
 
   const formatMessageTime = (dateStr: string) => {
     const date = new Date(dateStr)
@@ -56,9 +123,6 @@ export default function Messaging() {
     return new Date(b.latestMessageTime).getTime() - new Date(a.latestMessageTime).getTime()
   })
 
-  const currentUserId = token
-  ? JSON.parse(atob(token.split('.')[1])).userId
-  : null
 
   const getConversationName = (conv: Conversation) => {
   if (conv.name) return conv.name

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -24,7 +24,6 @@ export async function api<T>(endpoint: string, options: ApiOptions = {}): Promis
   })
 
   const text = await res.text()
-  console.log(`[api] ${method} ${endpoint} → ${res.status}`, text)
   let data: Record<string, unknown> = {}
   if (text) {
     try {

--- a/packages/frontend/src/utils/socket.ts
+++ b/packages/frontend/src/utils/socket.ts
@@ -1,0 +1,20 @@
+import { io, Socket } from "socket.io-client";
+
+let socket: Socket | null = null;
+
+export function getSocket(token: string) {
+    if (!socket) {
+        socket = io(import.meta.env.VITE_SOCKET_URL, {
+            auth: { token },
+            transports: ["websocket"],
+        });
+    }
+    return socket;
+}
+
+export function disconnectSocket() {
+    if (socket) {
+        socket.disconnect();
+        socket = null;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      redis:
+        specifier: ^5.12.1
+        version: 5.12.1
+      socket.io:
+        specifier: ^4.8.3
+        version: 4.8.3
     devDependencies:
       '@types/bcrypt':
         specifier: ^6.0.0
@@ -546,6 +552,42 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -697,6 +739,9 @@ packages:
     resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
     cpu: [x64]
     os: [win32]
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -901,6 +946,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -984,6 +1032,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.55.0':
     resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1049,6 +1100,10 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1090,6 +1145,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
@@ -1180,6 +1239,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1219,6 +1282,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1353,6 +1420,14 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.7:
+    resolution: {integrity: sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==}
+    engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
@@ -1882,8 +1957,16 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -1930,6 +2013,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -1956,6 +2043,10 @@ packages:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2207,6 +2298,10 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -2328,6 +2423,17 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2567,6 +2673,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -2983,6 +3101,26 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@redis/bloom@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/client@5.12.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/search@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3071,6 +3209,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@stablelib/base64@1.0.1': {}
 
@@ -3219,6 +3359,10 @@ snapshots:
     dependencies:
       '@types/node': 25.2.3
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.2.3
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3303,6 +3447,10 @@ snapshots:
   '@types/strip-json-comments@0.0.30': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.2.3
 
   '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3403,6 +3551,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -3441,6 +3594,8 @@ snapshots:
   aws-ssl-profiles@1.1.2: {}
 
   balanced-match@1.0.2: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -3559,6 +3714,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3582,6 +3739,11 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   create-require@1.1.1: {}
 
@@ -3685,6 +3847,25 @@ snapshots:
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.7:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 25.2.3
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enhanced-resolve@5.20.0:
     dependencies:
@@ -4220,7 +4401,13 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -4266,6 +4453,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   negotiator@1.0.0: {}
 
   node-addon-api@8.6.0: {}
@@ -4283,6 +4472,8 @@ snapshots:
       citty: 0.2.1
       pathe: 2.0.3
       tinyexec: 1.0.2
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -4519,6 +4710,17 @@ snapshots:
       - '@types/react'
       - redux
 
+  redis@5.12.1:
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1)
+      '@redis/client': 5.12.1
+      '@redis/json': 5.12.1(@redis/client@5.12.1)
+      '@redis/search': 5.12.1(@redis/client@5.12.1)
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -4671,6 +4873,36 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  socket.io-adapter@2.5.6:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.7
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   source-map-js@1.2.1: {}
 
@@ -4880,6 +5112,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.18.3: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(redux@5.0.1)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -1421,6 +1424,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
@@ -2427,6 +2433,10 @@ packages:
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
@@ -2685,6 +2695,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3848,6 +3862,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   engine.io-parser@5.2.3: {}
 
   engine.io@6.6.7:
@@ -4883,6 +4909,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -5114,6 +5151,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

- Implemented Redis Pub/Sub realtime messaging support for live chat updates
- Added Socket.IO integration between backend and frontend
- Enabled live message delivery without page refresh
- Added live inbox preview updates when new messages are sent
- Added live unread/read state syncing across clients

---

## Changes Made

### Backend

- Added Redis Pub/Sub event publishing for:
  - `message.created`
  - `conversation.updated`
  - `message.read`

- Added messaging subscriber to:
  - listen for Redis events
  - broadcast events to connected socket rooms

- Added Socket.IO room support for:
  - joining conversation rooms
  - leaving conversation rooms
  - broadcasting conversation-specific events

### Frontend

- Added Socket.IO client integration
- Added socket utility for shared socket connection management

- Updated conversation detail page to:
  - subscribe to live message events
  - subscribe to live read receipt events
  - update messages in realtime

- Updated inbox page to:
  - subscribe to live conversation updates
  - update latest message preview in realtime
  - update unread indicators in realtime

---

## New Dependency

### Frontend now uses:

- `socket.io-client`

### After pulling this branch, run:

```bash
pnpm install
```

This is required to install the new frontend socket dependency.

---

## Testing

### Realtime messaging test

1. Pull branch

2. Run:

```bash
pnpm install
pnpm dev
```

3. Open two browser windows
4. Log into two separate accounts  
5. Open the same conversation on both clients  
6. Send messages between both users  

**Expected:**

- messages appear instantly on both clients  
- inbox previews update instantly  
- unread indicators update instantly  
- read state updates across clients  
- no page refresh required