### PR TITLE
node modules bug fix

### DIFF
--- a/.github/workflows/main_gameplan-backend.yml
+++ b/.github/workflows/main_gameplan-backend.yml
@@ -47,6 +47,7 @@ jobs:
           mkdir -p deploy/node_modules/@gameplan/shared
           cp -r packages/shared/dist deploy/node_modules/@gameplan/shared/dist
           cp packages/shared/package.json deploy/node_modules/@gameplan/shared/package.json
+          printf '[config]\nSCM_DO_BUILD_DURING_DEPLOYMENT=false' > deploy/.deployment
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Azure is creating its own node_module file so I added    `printf '[config]\nSCM_DO_BUILD_DURING_DEPLOYMENT=false' > deploy/.deployment` to prevent that.